### PR TITLE
Support 'script' key to shortcut to arbitrary executable

### DIFF
--- a/menuinst/win32.py
+++ b/menuinst/win32.py
@@ -74,12 +74,17 @@ class ShortCut(object):
             cmd = join(self.prefix, 'pythonw.exe')
             args = ['-m', 'webbrowser', '-t', self.shortcut['webbrowser']]
 
+        elif "script" in self.shortcut:
+            cmd = join(self.prefix, self.shortcut["script"].replace('/', '\\'))
+            args = [self.shortcut['scriptargument']]
+
         else:
             raise Exception("Nothing to do: %r" % self.shortcut)
 
         workdir = self.shortcut.get('workdir', '')
         icon = self.shortcut.get('icon', '')
         for a, b in [
+            ('${PREFIX}', self.prefix),
             ('${PYTHON_SCRIPTS}', join(self.prefix, 'Scripts')),
             ('${MENU_DIR}', join(self.prefix, 'Menu')),
             ('${PERSONALDIR}', get_folder_path('CSIDL_PERSONAL')),


### PR DESCRIPTION
Allows 

``` json
{
    "name": "Launcher",
    "icon": "${MENU_DIR}/launcher.ico",
    "script": "node-webkit/nw.exe",
    "scriptargument": "${PREFIX}/node-webkit/launcher"
  }
```

to create a shortcut which executes `$PREFIX\node-webkit\nw.exe $PREFIX\node-webkit\launcher`.