### PR TITLE
Include patches used in conda-standalone

### DIFF
--- a/menuinst/__init__.py
+++ b/menuinst/__init__.py
@@ -24,8 +24,8 @@ elif sys.platform == 'win32':
     from .win_elevate import isUserAdmin, runAsAdmin
 
 
-def _install(path, remove=False, prefix=sys.prefix, mode=None):
-    if abspath(prefix) == abspath(sys.prefix):
+def _install(path, remove=False, prefix=sys.prefix, mode=None, root_prefix=sys.prefix):
+    if abspath(prefix) == abspath(root_prefix):
         env_name = None
     else:
         env_name = basename(prefix)
@@ -37,7 +37,7 @@ def _install(path, remove=False, prefix=sys.prefix, mode=None):
         menu_name = 'Python-%d.%d' % sys.version_info[:2]
 
     shortcuts = data['menu_items']
-    m = Menu(menu_name, prefix=prefix, env_name=env_name, mode=mode)
+    m = Menu(menu_name, prefix=prefix, env_name=env_name, mode=mode, root_prefix=root_prefix)
     if remove:
         for sc in shortcuts:
             ShortCut(m, sc).remove()
@@ -48,29 +48,31 @@ def _install(path, remove=False, prefix=sys.prefix, mode=None):
             ShortCut(m, sc).create()
 
 
-def install(path, remove=False, prefix=sys.prefix, recursing=False):
+def install(path, remove=False, prefix=sys.prefix, recursing=False, root_prefix=sys.prefix):
     """
-    install Menu and shortcuts
+    Install Menu and shortcuts
+    
+    # Specifying `root_prefix` is used with conda-standalone, because we can't use
+    # `sys.prefix`, therefore we need to specify it  
     """
-    # this sys.prefix is intentional.  We want to reflect the state of the root installation.
-    if sys.platform == 'win32' and not exists(join(sys.prefix, '.nonadmin')):
-        if isUserAdmin():
-            _install(path, remove, prefix, mode='system')
+    # this root_prefix is intentional.  We want to reflect the state of the root installation.
+    if sys.platform == 'win32' and not exists(join(root_prefix, '.nonadmin')):
+        if not isUserAdmin():
+            _install(path, remove, prefix, mode='system', root_prefix=root_prefix)
         else:
             from pywintypes import error
+            retcode = 1
             try:
                 if not recursing:
-                    retcode = runAsAdmin([join(sys.prefix, 'python'), '-c',
-                                          "import menuinst; menuinst.install(%r, %r, %r, %r)" % (
-                                              path, bool(remove), prefix, True)])
-                else:
-                    retcode = 1
+                    retcode = runAsAdmin([join(root_prefix, 'python'), '-c',
+                                          "import menuinst; menuinst.install(%r, %r, %r, %r, %r)" % (
+                                              path, bool(remove), prefix, True, root_prefix)])
             except error:
-                retcode = 1
+                pass
 
             if retcode != 0:
                 logging.warn("Insufficient permissions to write menu folder.  "
                              "Falling back to user location")
-                _install(path, remove, prefix, mode='user')
+                _install(path, remove, prefix, mode='user', root_prefix=root_prefix)
     else:
-        _install(path, remove, prefix, mode='user')
+        _install(path, remove, prefix, mode='user', root_prefix=root_prefix)

--- a/menuinst/__init__.py
+++ b/menuinst/__init__.py
@@ -51,13 +51,13 @@ def _install(path, remove=False, prefix=sys.prefix, mode=None, root_prefix=sys.p
 def install(path, remove=False, prefix=sys.prefix, recursing=False, root_prefix=sys.prefix):
     """
     Install Menu and shortcuts
-    
+
     # Specifying `root_prefix` is used with conda-standalone, because we can't use
     # `sys.prefix`, therefore we need to specify it  
     """
     # this root_prefix is intentional.  We want to reflect the state of the root installation.
     if sys.platform == 'win32' and not exists(join(root_prefix, '.nonadmin')):
-        if not isUserAdmin():
+        if isUserAdmin():
             _install(path, remove, prefix, mode='system', root_prefix=root_prefix)
         else:
             from pywintypes import error


### PR DESCRIPTION
- [x] includes patches used in https://github.com/conda-forge/conda-standalone-feedstock and https://github.com/AnacondaRecipes/conda-standalone-feedstock 
- [x] resolve conflict with menuinst 1.4.17

These two commits are used as patch in https://github.com/conda-forge/conda-standalone-feedstock/pull/18.