### PR TITLE
provide no_console flag

### DIFF
--- a/cwp.py
+++ b/cwp.py
@@ -5,13 +5,23 @@ import os
 import sys
 import subprocess
 from os.path import join, pathsep
+import argparse
 
 from menuinst.knownfolders import FOLDERID, get_folder_path, PathNotFoundException
 
-# call as: python cwp.py PREFIX ARGs...
+# call as: python cwp.py [--no-console] PREFIX ARGs...
+parser = argparse.ArgumentParser()
+parser.add_argument("--no-console", action="store_true",
+               help="Create subprocess with CREATE_NO_WINDOW flag.")
+parser.add_argument("prefix",
+               help="Prefix to be 'activated' before calling `args`.")
+parser.add_argument("args", nargs="*",
+               help="Command (and arguments) to be executed.")
+parsed_args = parser.parse_args()
 
-prefix = sys.argv[1]
-args = sys.argv[2:]
+no_console = parsed_args.no_console
+prefix = parsed_args.prefix
+args = parsed_args.args
 
 new_paths = pathsep.join([prefix,
                          join(prefix, "Library", "mingw-w64", "bin"),
@@ -27,4 +37,8 @@ if exception:
     documents_folder, exception = get_folder_path(FOLDERID.PublicDocuments)
 if not exception:
     os.chdir(documents_folder)
-sys.exit(subprocess.call(args, env=env))
+
+creationflags = {}
+if no_console:
+    creationflags["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+sys.exit(subprocess.call(args, env=env, **creationflags))

--- a/menuinst/win32.py
+++ b/menuinst/win32.py
@@ -295,6 +295,7 @@ class ShortCut(object):
         env_pyw = join(prefix, u"pythonw.exe")
         cwp_py  = [root_py,  join(unicode_root_prefix, u'cwp.py'), prefix, env_py]
         cwp_pyw = [root_pyw, join(unicode_root_prefix, u'cwp.py'), prefix, env_pyw]
+        cwp_no_console = [root_pyw, join(unicode_root_prefix, u'cwp.py'), "--no-console", prefix, env_py]
         if "pywscript" in self.shortcut:
             args = cwp_pyw
             fix_win_slashes = [len(args)]
@@ -303,6 +304,10 @@ class ShortCut(object):
             args = cwp_py
             fix_win_slashes = [len(args)]
             args += self.shortcut["pyscript"].split()
+        elif "pywscript_no_console" in self.shortcut:
+            args = cwp_no_console
+            fix_win_slashes = [len(args)]
+            args += self.shortcut["pywscript_no_console"].split()
         elif "webbrowser" in self.shortcut:
             args = [root_pyw, '-m', 'webbrowser', '-t', self.shortcut['webbrowser']]
         elif "script" in self.shortcut:


### PR DESCRIPTION
Currently there are several ways to add a shortcut:
* `script` + `scriptarguments` -> `ROOT_PYTHON ROOT/cwp.py script scriptarguments`
* `pyscript` -> `ROOT_PYTHON ROOT/cwp.py ENV_PYTHON ENV_SCRIPTS/some_script.py`
* `pywscript` -> `ROOT_PYTHONW ROOT/cwp.py ENV_PYTHONW ENV_SCRIPTS/some_script.py`

In all cases, `cwp.py` will launch a subprocess with a patched PATH env var.

The difference between `pyscript` and `pywscript` is that they will use `python.exe` and `pythonw.exe`, respectively. PythonW has the property of not creating a CMD console to launch. However, when PythonW is also used as the subprocess executable, it will kill the UI window instantly. 

This is happening to us at Napari, where we can use `pyscript` to launch the PyQT UI perfectly (but we end up with that ugly console in the background). `pywscript` as it is, will launch the app but it will flash and die instantly. We've found that the following combination results in a working UI with no background console: use `pythonw` to call `cwp.py` and launch a subprocess using the regular `python.exe` but with a `CREATE_NO_WINDOW` flag.

This is what this new option `pywscript_no_console` implements. Documentation should be added to the Wiki as well if this is merged as it is.

Instead of new `pyscript` derivative, I also thought of adding a configuration parameter `cwp_flags`. This will allow the user to specify extra CLI flags for `cwp.py`, but right now there's only one (introduced in this PR), so I don't think it's too useful.

I also changed the CLI parsing to use `argparse` instead of that `sys.argv` hack.

