### PR TITLE
fix support for osx

### DIFF
--- a/menuinst/utils.py
+++ b/menuinst/utils.py
@@ -1,7 +1,21 @@
 import os
+import sys
 import shutil
-from os.path import isdir, isfile, islink
+from os.path import  isdir, isfile, islink, join
 
+non_url_safe = ('"', '#', '$', '%', '&', '+',
+                ',', '/', ':', ';', '=', '?',
+                '@', '[', '\\', ']', '^', '`',
+                '{', '|', '}', '~', "'")
+translate_table = {ord(char): u'' for char in non_url_safe}
+on_win = sys.platform == 'win32'
+
+if on_win:
+    bin_dir_name = 'Scripts'
+    rel_site_packages = r'Lib\site-packages'
+else:
+    bin_dir_name = 'bin'
+    rel_site_packages = 'lib/python%i.%i/site-packages' % sys.version_info[:2]
 
 
 def rm_empty_dir(path):
@@ -20,3 +34,26 @@ def rm_rf(path):
 
     elif isdir(path):
         shutil.rmtree(path)
+
+
+def get_executable(prefix):
+    if on_win:
+        paths = [prefix, join(prefix, bin_dir_name)]
+        for path in paths:
+            executable = join(path, 'python.exe')
+            if isfile(executable):
+                return executable
+    else:
+        path = join(prefix, bin_dir_name, 'python')
+        if isfile(path):
+            from subprocess import Popen, PIPE
+            cmd = [path, '-c', 'import sys;print sys.executable']
+            p = Popen(cmd, stdout=PIPE)
+            return p.communicate()[0].strip()
+    return sys.executable
+
+
+def slugify(text):
+    text = text.translate(translate_table)
+    text = u'_'.join(text.split())
+    return text


### PR DESCRIPTION
This PR adds the minimum amount of changes needed to make OSX applications work again. It's not the most elegant code, but let's start small.

Summary of changes:

* Recover `utils.get_executable` from the original `appinst`
* Fix class signatures
* Conform to the `menuinst.install(...)` API expected by `conda` (same as windows)
* Comply with the modern `plistlib` API
* Slugify script name (last component of`/Applications/${NAME}.app/Contents/MacOS/${NAME}`) 
* Bring some placeholders used on Windows too