### PR TITLE
Fix support for linux

### DIFF
--- a/menuinst/freedesktop.py
+++ b/menuinst/freedesktop.py
@@ -23,9 +23,10 @@ def make_desktop_entry(d):
     if isinstance(d['cmd'], list):
         d['cmd'] = ' '.join(d['cmd'])
 
-    assert isinstance(d['terminal'], bool)
-    d['terminal'] = {False: 'false', True: 'true'}[d['terminal']]
+    assert isinstance(d.get('terminal', False), bool)
+    d['terminal'] = {False: 'false', True: 'true'}[d.get('terminal', False)]
 
+    print(d['path'])
     fo = open(d['path'], "w")
     fo.write("""\
 [Desktop Entry]

--- a/menuinst/utils.py
+++ b/menuinst/utils.py
@@ -1,7 +1,21 @@
 import os
+import sys
 import shutil
-from os.path import isdir, isfile, islink
+from os.path import  isdir, isfile, islink, join
 
+non_url_safe = ('"', '#', '$', '%', '&', '+',
+                ',', '/', ':', ';', '=', '?',
+                '@', '[', '\\', ']', '^', '`',
+                '{', '|', '}', '~', "'")
+translate_table = {ord(char): u'' for char in non_url_safe}
+on_win = sys.platform == 'win32'
+
+if on_win:
+    bin_dir_name = 'Scripts'
+    rel_site_packages = r'Lib\site-packages'
+else:
+    bin_dir_name = 'bin'
+    rel_site_packages = 'lib/python%i.%i/site-packages' % sys.version_info[:2]
 
 
 def rm_empty_dir(path):
@@ -20,3 +34,26 @@ def rm_rf(path):
 
     elif isdir(path):
         shutil.rmtree(path)
+
+
+def get_executable(prefix):
+    if on_win:
+        paths = [prefix, join(prefix, bin_dir_name)]
+        for path in paths:
+            executable = join(path, 'python.exe')
+            if isfile(executable):
+                return executable
+    else:
+        path = join(prefix, bin_dir_name, 'python')
+        if isfile(path):
+            from subprocess import Popen, PIPE
+            cmd = [path, '-c', 'import sys;print sys.executable']
+            p = Popen(cmd, stdout=PIPE)
+            return p.communicate()[0].strip()
+    return sys.executable
+
+
+def slugify(text):
+    text = text.translate(translate_table)
+    text = u'_'.join(text.split())
+    return text

--- a/menuinst/utils.py
+++ b/menuinst/utils.py
@@ -47,9 +47,9 @@ def get_executable(prefix):
         path = join(prefix, bin_dir_name, 'python')
         if isfile(path):
             from subprocess import Popen, PIPE
-            cmd = [path, '-c', 'import sys;print sys.executable']
+            cmd = [path, '-c', 'import sys;print(sys.executable)']
             p = Popen(cmd, stdout=PIPE)
-            return p.communicate()[0].strip()
+            return p.communicate()[0].strip().decode()
     return sys.executable
 
 


### PR DESCRIPTION
Similar to #88 (branched out from that one, review it first)

Adds:

* `menuinst.install` compliance
* Placeholders on Linux (same as MacOS)
* Minor fixes (str/bytes, py2k syntax, etc)

I can't test this locally (no GUI), but the `.desktop` files are created as expected. Maybe we need to add support for env activation (right now it just calls whatever the user wants, no magic).