### PR TITLE
Copy ShellExecuteEx from conda to replace pywin32

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 30
     env:
-      dependencies: pywin32
       test-dependencies: pytest pytest-cov conda
     strategy:
       fail-fast: false

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+Unreleased:
+------------------
+  * Remove pywin32 dependency (#103)
+
 2021-09-10 1.4.18:
 ------------------
   * Merge in various patches used by conda-standalone (#85)

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,8 @@ if sys.platform == "win32":
                        "comdlg32", "advapi32", "shell32", "ole32", "oleaut32",
                        "uuid", "odbc32", "odbccp32"]
             )]
-    install_requires = ['pywin32']
 else:
     extensions = []
-    install_requires = []
 
 
 setup(
@@ -31,7 +29,7 @@ setup(
     long_description = open('README.rst').read(),
     ext_modules = extensions,
     include_package_data = True,
-    install_requires = install_requires,
+    install_requires = [],
     package_data = {"menuinst" : ["*.icns"]},
     license = "BSD",
     packages = ['menuinst'],


### PR DESCRIPTION
Remove the pywin32 dependency which does not build on pypy

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->


cc @mbargull, @mattip, @h-vetinari

Fixes #41 