### PR TITLE
Fix segfaults on Windows while building conda packages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,19 +87,19 @@ jobs:
   # canary builds
   build:
     name: Canary Build
-    needs: [run_test_suite]
+    # needs: [run_test_suite]
     # only build canary build if
     # - prior steps succeeded,
     # - this is the main repo, and
     # - we are on the main, feature, or release branch
-    if: >-
-      always()
-      && !github.event.repository.fork
-      && (
-        github.ref_name == 'main'
-        || startsWith(github.ref_name, 'feature/')
-        || endsWith(github.ref_name, '.x')
-      )
+    # if: >-
+    #   always()
+    #   && !github.event.repository.fork
+    #   && (
+    #     github.ref_name == 'main'
+    #     || startsWith(github.ref_name, 'feature/')
+    #     || endsWith(github.ref_name, '.x')
+    #   )
     strategy:
       matrix:
         include:
@@ -155,5 +155,5 @@ jobs:
           subdir: ${{ matrix.subdir }}
           anaconda-org-channel: conda-canary
           anaconda-org-label: ${{ env.ANACONDA_ORG_LABEL }}
-          anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}
+          anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKENNNN }}
           conda-build-arguments: '--override-channels -c conda-forge -c defaults'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,7 @@ jobs:
     #     || endsWith(github.ref_name, '.x')
     #   )
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runner: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,19 +87,19 @@ jobs:
   # canary builds
   build:
     name: Canary Build
-    # needs: [run_test_suite]
+    needs: [run_test_suite]
     # only build canary build if
     # - prior steps succeeded,
     # - this is the main repo, and
     # - we are on the main, feature, or release branch
-    # if: >-
-    #   always()
-    #   && !github.event.repository.fork
-    #   && (
-    #     github.ref_name == 'main'
-    #     || startsWith(github.ref_name, 'feature/')
-    #     || endsWith(github.ref_name, '.x')
-    #   )
+    if: >-
+      always()
+      && !github.event.repository.fork
+      && (
+        github.ref_name == 'main'
+        || startsWith(github.ref_name, 'feature/')
+        || endsWith(github.ref_name, '.x')
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -156,5 +156,5 @@ jobs:
           subdir: ${{ matrix.subdir }}
           anaconda-org-channel: conda-canary
           anaconda-org-label: ${{ env.ANACONDA_ORG_LABEL }}
-          anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKENNNN }}
+          anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}
           conda-build-arguments: '--override-channels -c conda-forge -c defaults'

--- a/news/144-add-canaries
+++ b/news/144-add-canaries
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Add recipe and CI workflow steps to build and upload canaries to `conda-canary`. (#144)
+* Add recipe and CI workflow steps to build and upload canaries to `conda-canary`. (#144, #145)
 
 ### Bug fixes
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ build:
     # Apparently these files make the post-build linkage analysis crash
     # and we should not need them on Windows
     - del /q "{{ SRC_DIR }}\\menuinst\\data\\osx_launcher_*"  # [win]
+    - del /q "{{ SRC_DIR }}\\menuinst\\data\\appkit_launcher_*"  # [win]
     - {{ PYTHON }} -m pip install . -vv
     - copy "%SRC_DIR%\\cwp.py" "%PREFIX%\\"  # [win]
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Windows canaries failed before hitting the test phase with a segfault, possibly caused by the presence of OS-foreign binaries in the package. Deleting them before running the install (since they are not used on Windows anyway) does the trick.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
