### PR TITLE
Render placeholders in `menu_name`

### DIFF
--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -49,7 +49,7 @@ class WindowsMenu(Menu):
         In this property we only report the path to the Start menu.
         For other menus, check their respective properties.
         """
-        return Path(windows_folder_path(self.mode, False, "start")) / self.name
+        return Path(windows_folder_path(self.mode, False, "start")) / self.render(self.name)
 
     @property
     def quick_launch_location(self) -> Path:

--- a/news/175-render-menu-name
+++ b/news/175-render-menu-name
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Render placeholders in `menu_name` key. (#175)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/data/jsons/sys-prefix.json
+++ b/tests/data/jsons/sys-prefix.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://schemas.conda.io/menuinst-1.schema.json",
-    "menu_name": "Sys.Prefix",
+    "menu_name": "Sys.Prefix {{ DISTRIBUTION_NAME }}",
     "menu_items": [
         {
             "name": "Sys.Prefix",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,14 +139,15 @@ def check_output_from_shortcut(
 
 
 def test_install_prefix(delete_files):
-    _, paths, base_prefix, _ = check_output_from_shortcut(
-        delete_files, "sys-prefix.json", expected_output=sys.prefix
-    )
+    check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
+
+
+def test_placeholders(delete_files):
+    _, paths, base_prefix, _ = check_output_from_shortcut(delete_files, "sys-prefix.json")
     if sys.platform == "win32":
         for path in paths:
-            if path.suffix == ".lnk":
-                menu_dir = path.parent
-                assert menu_dir.name == f"Sys.Prefix {Path(base_prefix).name}"
+            if path.suffix == ".lnk" and path.parent.name.startswith("Sys.Prefix"):
+                assert path.parent.name == f"Sys.Prefix {Path(base_prefix).name}"
         else:
             raise AssertionError("Didn't find .lnk")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,16 +139,22 @@ def check_output_from_shortcut(
 
 
 def test_install_prefix(delete_files):
-    _, paths, base_prefix, _ = check_output_from_shortcut(
-        delete_files, "sys-prefix.json", expected_output=sys.prefix
+    check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
+
+
+@pytest.mark.skipif(PLATFORM != "win", reason="Windows only")
+def test_placeholders_in_menu_name(delete_files):
+    abs_json_path, paths, tmp_base_path, _ = check_output_from_shortcut(
+        delete_files,
+        "sys-prefix.json",
+        expected_output=sys.prefix,
     )
-    if PLATFORM == "win":
-        for path in paths:
-            print(path)
-            if path.is_dir() and "Start Menu" in path.parts:
-                assert path.name == f"Sys.Prefix {Path(base_prefix).name}"
-        else:
-            raise AssertionError("Didn't find Start Menu")
+    for path in paths:
+        if path.is_dir() and "Start Menu" in path.parts:
+            assert path.name == f"Sys.Prefix {Path(tmp_base_path).name}"
+    else:
+        raise AssertionError("Didn't find Start Menu")
+    remove(abs_json_path, base_prefix=tmp_base_path)
 
 
 def test_precommands(delete_files):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -142,14 +142,14 @@ def test_install_prefix(delete_files):
     check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
 
 
+@pytest.mark.skipif(PLATFORM != "win", reason="Windows only")
 def test_placeholders(delete_files):
     _, paths, base_prefix, _ = check_output_from_shortcut(delete_files, "sys-prefix.json")
-    if sys.platform == "win32":
-        for path in paths:
-            if path.suffix == ".lnk" and path.parent.name.startswith("Sys.Prefix"):
-                assert path.parent.name == f"Sys.Prefix {Path(base_prefix).name}"
-        else:
-            raise AssertionError("Didn't find .lnk")
+    for path in paths:
+        if path.suffix == ".lnk" and path.parent.name.startswith("Sys.Prefix"):
+            assert path.parent.name == f"Sys.Prefix {Path(base_prefix).name}"
+    else:
+        raise AssertionError("Didn't find .lnk")
 
 
 def test_precommands(delete_files):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,7 +139,16 @@ def check_output_from_shortcut(
 
 
 def test_install_prefix(delete_files):
-    check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
+    _, paths, _ = check_output_from_shortcut(
+        delete_files, "sys-prefix.json", expected_output=sys.prefix
+    )
+    if sys.platform == "win32":
+        for path in paths:
+            if path.suffix == ".lnk":
+                menu_dir = path.parent
+                assert menu_dir.name == f"Sys.Prefix {Path(sys.prefix).name}"
+        else:
+            raise AssertionError("Didn't find .lnk")
 
 
 def test_precommands(delete_files):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,7 +139,9 @@ def check_output_from_shortcut(
 
 
 def test_install_prefix(delete_files):
-    _, paths, base_prefix, _ = check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
+    _, paths, base_prefix, _ = check_output_from_shortcut(
+        delete_files, "sys-prefix.json", expected_output=sys.prefix
+    )
     if PLATFORM == "win":
         for path in paths:
             if path.is_dir() and "Start Menu" in path.parts:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -139,17 +139,13 @@ def check_output_from_shortcut(
 
 
 def test_install_prefix(delete_files):
-    check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
-
-
-@pytest.mark.skipif(PLATFORM != "win", reason="Windows only")
-def test_placeholders(delete_files):
-    _, paths, base_prefix, _ = check_output_from_shortcut(delete_files, "sys-prefix.json")
-    for path in paths:
-        if path.suffix == ".lnk" and path.parent.name.startswith("Sys.Prefix"):
-            assert path.parent.name == f"Sys.Prefix {Path(base_prefix).name}"
-    else:
-        raise AssertionError("Didn't find .lnk")
+    _, paths, base_prefix, _ = check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
+    if PLATFORM == "win":
+        for path in paths:
+            if path.is_dir() and "Start Menu" in path.parts:
+                assert path.name == f"Sys.Prefix {Path(base_prefix).name}"
+        else:
+            raise AssertionError("Didn't find Start Menu")
 
 
 def test_precommands(delete_files):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,17 +144,16 @@ def test_install_prefix(delete_files):
 
 @pytest.mark.skipif(PLATFORM != "win", reason="Windows only")
 def test_placeholders_in_menu_name(delete_files):
-    abs_json_path, paths, tmp_base_path, _ = check_output_from_shortcut(
+    _, paths, tmp_base_path, _ = check_output_from_shortcut(
         delete_files,
         "sys-prefix.json",
         expected_output=sys.prefix,
     )
     for path in paths:
-        if path.is_dir() and "Start Menu" in path.parts:
+        if path.suffix == ".lnk" and "Start Menu" in path.parts:
             assert path.name == f"Sys.Prefix {Path(tmp_base_path).name}"
     else:
         raise AssertionError("Didn't find Start Menu")
-    remove(abs_json_path, base_prefix=tmp_base_path)
 
 
 def test_precommands(delete_files):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,6 +144,7 @@ def test_install_prefix(delete_files):
     )
     if PLATFORM == "win":
         for path in paths:
+            print(path)
             if path.is_dir() and "Start Menu" in path.parts:
                 assert path.name == f"Sys.Prefix {Path(base_prefix).name}"
         else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -152,6 +152,7 @@ def test_placeholders_in_menu_name(delete_files):
     for path in paths:
         if path.suffix == ".lnk" and "Start Menu" in path.parts:
             assert path.parent.name == f"Sys.Prefix {Path(tmp_base_path).name}"
+            break
     else:
         raise AssertionError("Didn't find Start Menu")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -135,18 +135,18 @@ def check_output_from_shortcut(
     if expected_output is not None:
         assert output.strip() == expected_output
 
-    return abs_json_path, paths, output
+    return abs_json_path, paths, tmp_base_path, output
 
 
 def test_install_prefix(delete_files):
-    _, paths, _ = check_output_from_shortcut(
+    _, paths, base_prefix, _ = check_output_from_shortcut(
         delete_files, "sys-prefix.json", expected_output=sys.prefix
     )
     if sys.platform == "win32":
         for path in paths:
             if path.suffix == ".lnk":
                 menu_dir = path.parent
-                assert menu_dir.name == f"Sys.Prefix {Path(sys.prefix).name}"
+                assert menu_dir.name == f"Sys.Prefix {Path(base_prefix).name}"
         else:
             raise AssertionError("Didn't find .lnk")
 
@@ -159,7 +159,7 @@ def test_precommands(delete_files):
 
 @pytest.mark.skipif(PLATFORM != "osx", reason="macOS only")
 def test_entitlements(delete_files):
-    json_path, paths, _ = check_output_from_shortcut(
+    json_path, paths, *_ = check_output_from_shortcut(
         delete_files, "entitlements.json", remove_after=False, expected_output="entitlements"
     )
     # verify signature
@@ -191,7 +191,7 @@ def test_entitlements(delete_files):
 
 @pytest.mark.skipif(PLATFORM != "osx", reason="macOS only")
 def test_no_entitlements_no_signature(delete_files):
-    json_path, paths, _ = check_output_from_shortcut(
+    json_path, paths, *_ = check_output_from_shortcut(
         delete_files, "sys-prefix.json", remove_after=False, expected_output=sys.prefix
     )
     app_dir = next(p for p in paths if p.name.endswith(".app"))
@@ -207,7 +207,7 @@ def test_no_entitlements_no_signature(delete_files):
 
 @pytest.mark.skipif(PLATFORM != "osx", reason="macOS only")
 def test_info_plist(delete_files):
-    json_path, paths, _ = check_output_from_shortcut(
+    json_path, paths, *_ = check_output_from_shortcut(
         delete_files, "entitlements.json", remove_after=False, expected_output="entitlements"
     )
     app_dir = next(p for p in paths if p.name.endswith(".app"))
@@ -226,7 +226,7 @@ def test_info_plist(delete_files):
 
 @pytest.mark.skipif(PLATFORM != "osx", reason="macOS only")
 def test_osx_symlinks(delete_files):
-    json_path, paths, output = check_output_from_shortcut(
+    json_path, paths, _, output = check_output_from_shortcut(
         delete_files, "osx_symlinks.json", remove_after=False
     )
     app_dir = next(p for p in paths if p.name.endswith(".app"))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -151,7 +151,7 @@ def test_placeholders_in_menu_name(delete_files):
     )
     for path in paths:
         if path.suffix == ".lnk" and "Start Menu" in path.parts:
-            assert path.name == f"Sys.Prefix {Path(tmp_base_path).name}"
+            assert path.parent.name == f"Sys.Prefix {Path(tmp_base_path).name}"
     else:
         raise AssertionError("Didn't find Start Menu")
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

I had forgotten to render placeholders found in the `menu_name` key. This fixes that behavior so folks can things like do `"menu_name": "{{ DISTRIBUTION_NAME }} shortcuts"` to customize the Start Menu directory.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
