### PR TITLE
Fix commands with arguments that start with "-"

### DIFF
--- a/menuinst/_legacy/cwp.py
+++ b/menuinst/_legacy/cwp.py
@@ -18,7 +18,9 @@ def main():
         "--no-console", action="store_true", help="Create subprocess with CREATE_NO_WINDOW flag."
     )
     parser.add_argument("prefix", help="Prefix to be 'activated' before calling `args`.")
-    parser.add_argument("args", nargs=argparse.REMAINDER, help="Command (and arguments) to be executed.")
+    parser.add_argument(
+        "args", nargs=argparse.REMAINDER, help="Command (and arguments) to be executed."
+    )
     parsed_args = parser.parse_args()
 
     no_console = parsed_args.no_console

--- a/menuinst/_legacy/cwp.py
+++ b/menuinst/_legacy/cwp.py
@@ -18,7 +18,7 @@ def main():
         "--no-console", action="store_true", help="Create subprocess with CREATE_NO_WINDOW flag."
     )
     parser.add_argument("prefix", help="Prefix to be 'activated' before calling `args`.")
-    parser.add_argument("args", nargs="*", help="Command (and arguments) to be executed.")
+    parser.add_argument("args", nargs=argparse.REMAINDER, help="Command (and arguments) to be executed.")
     parsed_args = parser.parse_args()
 
     no_console = parsed_args.no_console

--- a/menuinst/_legacy/cwp.py
+++ b/menuinst/_legacy/cwp.py
@@ -11,7 +11,7 @@ from os.path import join, pathsep
 from menuinst.knownfolders import FOLDERID, get_folder_path
 
 
-def main():
+def main(argv=None):
     # call as: python cwp.py [--no-console] PREFIX ARGs...
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -21,7 +21,7 @@ def main():
     parser.add_argument(
         "args", nargs=argparse.REMAINDER, help="Command (and arguments) to be executed."
     )
-    parsed_args = parser.parse_args()
+    parsed_args = parser.parse_args(argv)
 
     no_console = parsed_args.no_console
     prefix = parsed_args.prefix

--- a/tests/_legacy/test_cwp.py
+++ b/tests/_legacy/test_cwp.py
@@ -1,0 +1,10 @@
+import sys
+
+import pytest
+
+cwp = pytest.importorskip("menuinst._legacy.cwp", reason="Windows only")
+
+def test_cwp(capsys):
+    with pytest.raises(SystemExit):
+        cwp.main([sys.prefix, "python", "-c", "print('hello')"])
+        assert capsys.readouterr() == ("hello\n", "")

--- a/tests/_legacy/test_cwp.py
+++ b/tests/_legacy/test_cwp.py
@@ -1,11 +1,21 @@
 import sys
+from subprocess import check_output
 
 import pytest
 
 cwp = pytest.importorskip("menuinst._legacy.cwp", reason="Windows only")
 
 
-def test_cwp(capsys):
-    with pytest.raises(SystemExit):
-        cwp.main([sys.prefix, "python", "-c", "print('hello')"])
-        assert capsys.readouterr() == ("hello\n", "")
+def test_cwp():
+    out = check_output(
+        [
+            sys.executable,
+            cwp.__file__,
+            sys.prefix,
+            "python",
+            "-c",
+            "import sys; print(sys.prefix)",
+        ],
+        text=True,
+    )
+    assert out.strip() == sys.prefix

--- a/tests/_legacy/test_cwp.py
+++ b/tests/_legacy/test_cwp.py
@@ -4,6 +4,7 @@ import pytest
 
 cwp = pytest.importorskip("menuinst._legacy.cwp", reason="Windows only")
 
+
 def test_cwp(capsys):
     with pytest.raises(SystemExit):
         cwp.main([sys.prefix, "python", "-c", "print('hello')"])


### PR DESCRIPTION
Parameters that start with "-" are interpreted as a new argument. argparse.REMAINDER forces it to interpret all everything left in the command as a list of strings instead of new arguments. Fixes issue #177