### PR TITLE
Explicitly choose macos-13 for Intel runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   run_test_suite:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
       CONDA_NUMBER_CHANNEL_NOTICES: 0
@@ -32,14 +32,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows, ubuntu, macos]
+        os: [windows-latest, ubuntu-latest, macos-13]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
-          - os: macos
+          - os: macos-13
             python-version: "3.11"
-          - os: macos
+          - os: macos-13
             python-version: "3.10"
-          - os: macos
+          - os: macos-13
             python-version: "3.9"
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add Linux dependencies
-        if: matrix.os == 'ubuntu'
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get install libfile-mimeinfo-perl desktop-file-utils
           echo "XDG_UTILS_DEBUG_LEVEL=2" >> $GITHUB_ENV


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

See https://github.com/conda-incubator/setup-miniconda/issues/344 for context.

macos-latest may or may not provide ARM64 right now. The only way to ensure Intel from now on is macos-13.

We should add osx-arm64 tests in a later PR.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
