### PR TITLE
Add support for NSSupportsAutomaticGraphicsSwitching

### DIFF
--- a/menuinst/_schema.py
+++ b/menuinst/_schema.py
@@ -295,6 +295,8 @@ class MacOS(BasePlatformSpecific):
     If true, prevent a universal binary from being run under
     Rosetta emulation on an Intel-based Mac.
     """
+    NSSupportsAutomaticGraphicsSwitching: Optional[bool] = None
+    """If true, allows an OpenGL app to utilize the integrated GPU."""
     UTExportedTypeDeclarations: Optional[List[UTTypeDeclarationModel]] = None
     "The uniform type identifiers owned and exported by the app."
     UTImportedTypeDeclarations: Optional[List[UTTypeDeclarationModel]] = None

--- a/menuinst/data/menuinst.default.json
+++ b/menuinst/data/menuinst.default.json
@@ -47,6 +47,7 @@
           "LSMinimumSystemVersion": null,
           "LSMultipleInstancesProhibited": null,
           "LSRequiresNativeExecution": null,
+          "NSSupportsAutomaticGraphicsSwitching": null,
           "UTExportedTypeDeclarations": null,
           "UTImportedTypeDeclarations": null,
           "entitlements": null,

--- a/menuinst/data/menuinst.schema.json
+++ b/menuinst/data/menuinst.schema.json
@@ -468,6 +468,10 @@
           "title": "Lsrequiresnativeexecution",
           "type": "boolean"
         },
+        "NSSupportsAutomaticGraphicsSwitching": {
+          "title": "Nssupportsautomaticgraphicsswitching",
+          "type": "boolean"
+        },
         "UTExportedTypeDeclarations": {
           "title": "Utexportedtypedeclarations",
           "type": "array",

--- a/news/194-add-NSSupportsAutomaticGraphicsSwitching
+++ b/news/194-add-NSSupportsAutomaticGraphicsSwitching
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Support the `NSSupportsAutomaticGraphicsSwitching` flag for MacOS apps. (#194)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Some MacBooks have two GPUs, a discrete and an integrated GPU. While the former is more powerful, it also consumes more power. By default, the [discrete GPU](https://developer.apple.com/library/archive/qa/qa1734/_index.html) is used.

To allow apps using OpenGL to use the integrated GPU and be more energy-efficient, the [NSSupportsAutomaticGraphicsSwitching](https://developer.apple.com/documentation/bundleresources/information_property_list/nssupportsautomaticgraphicsswitching) needs to be set to `true`.

`menuinst` currently does not support this flag - this PR adds this property to the schema.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?