### PR TITLE
Render all menu name instances for Linux

### DIFF
--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -42,10 +42,6 @@ class LinuxMenu(Menu):
                 os.environ.get("XDG_DATA_HOME", "~/.local/share")
             ).expanduser()
 
-        # The names have to be rendered often, so store them for convenience
-        self._rendered_name = self.render(self.name)
-        self._slugified_name = self.render(self.name, slug=True)
-
         # XML Config paths
         self.system_menu_config_location = (
             self._system_config_directory / "menus" / "applications.menu"
@@ -53,7 +49,9 @@ class LinuxMenu(Menu):
         self.menu_config_location = self.config_directory / "menus" / "applications.menu"
         # .desktop / .directory paths
         self.directory_entry_location = (
-            self.data_directory / "desktop-directories" / f"{self._slugified_name}.directory"
+            self.data_directory
+            / "desktop-directories"
+            / f"{self.render(self.name, slug=True)}.directory"
         )
         self.desktop_entries_location = self.data_directory / "applications"
 
@@ -69,7 +67,7 @@ class LinuxMenu(Menu):
     def remove(self) -> Tuple[os.PathLike]:
         unlink(self.directory_entry_location, missing_ok=True)
         for fn in os.listdir(self.desktop_entries_location):
-            if fn.startswith(f"{self._slugified_name}_"):
+            if fn.startswith(f"{self.render(self.name, slug=True)}_"):
                 # found one shortcut, so don't remove the name from menu
                 return (self.directory_entry_location,)
         self._remove_this_menu()
@@ -100,7 +98,7 @@ class LinuxMenu(Menu):
             "[Desktop Entry]",
             "Type=Directory",
             "Encoding=UTF-8",
-            f"Name={self._rendered_name}",
+            f"Name={self.render(self.name)}",
         ]
         log.debug("Writing directory entry at %s", self.directory_entry_location)
         with open(self.directory_entry_location, "w") as f:
@@ -113,27 +111,29 @@ class LinuxMenu(Menu):
     #
 
     def _remove_this_menu(self):
-        log.debug("Editing %s to remove %s config", self.menu_config_location, self._rendered_name)
+        log.debug(
+            "Editing %s to remove %s config", self.menu_config_location, self.render(self.name)
+        )
         tree = ElementTree.parse(self.menu_config_location)
         root = tree.getroot()
         for elt in root.findall("Menu"):
-            if elt.find("Name").text == self._rendered_name:
+            if elt.find("Name").text == self.render(self.name):
                 root.remove(elt)
         self._write_menu_file(tree)
 
     def _has_this_menu(self) -> bool:
         root = ElementTree.parse(self.menu_config_location).getroot()
-        return any(e.text == self._rendered_name for e in root.findall("Menu/Name"))
+        return any(e.text == self.render(self.name) for e in root.findall("Menu/Name"))
 
     def _add_this_menu(self):
-        log.debug("Editing %s to add %s config", self.menu_config_location, self._rendered_name)
+        log.debug("Editing %s to add %s config", self.menu_config_location, self.render(self.name))
         tree = ElementTree.parse(self.menu_config_location)
         root = tree.getroot()
         menu_elt = add_xml_child(root, "Menu")
-        add_xml_child(menu_elt, "Name", self._rendered_name)
-        add_xml_child(menu_elt, "Directory", f"{self._slugified_name}.directory")
+        add_xml_child(menu_elt, "Name", self.render(self.name))
+        add_xml_child(menu_elt, "Directory", f"{self.render(self.name, slug=True)}.directory")
         inc_elt = add_xml_child(menu_elt, "Include")
-        add_xml_child(inc_elt, "Category", self._rendered_name)
+        add_xml_child(inc_elt, "Category", self.render(self.name))
         self._write_menu_file(tree)
 
     def _is_valid_menu_file(self) -> bool:

--- a/news/201-linux-render-all-menu-name-placeholders
+++ b/news/201-linux-render-all-menu-name-placeholders
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Render all menu name instances for Linux. (#201)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,13 +11,14 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile, mkdtemp
 from time import sleep, time
 from typing import Iterable, Tuple
+from xml.etree import ElementTree
 
 import pytest
 from conftest import DATA, PLATFORM
 
 from menuinst.api import install, remove
 from menuinst.platforms.osx import _lsregister
-from menuinst.utils import DEFAULT_PREFIX, logged_run
+from menuinst.utils import DEFAULT_PREFIX, logged_run, slugify
 
 
 def _poll_for_file_contents(path, timeout=10):
@@ -144,19 +145,40 @@ def test_install_prefix(delete_files):
     check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
 
 
-@pytest.mark.skipif(PLATFORM != "win", reason="Windows only")
+@pytest.mark.skipif(PLATFORM == "osx", reason="No menu names on MacOS")
 def test_placeholders_in_menu_name(delete_files):
     _, paths, tmp_base_path, _ = check_output_from_shortcut(
         delete_files,
         "sys-prefix.json",
         expected_output=sys.prefix,
     )
-    for path in paths:
-        if path.suffix == ".lnk" and "Start Menu" in path.parts:
-            assert path.parent.name == f"Sys.Prefix {Path(tmp_base_path).name}"
-            break
-    else:
-        raise AssertionError("Didn't find Start Menu")
+    if PLATFORM == "win":
+        for path in paths:
+            if path.suffix == ".lnk" and "Start Menu" in path.parts:
+                assert path.parent.name == f"Sys.Prefix {Path(tmp_base_path).name}"
+                break
+        else:
+            raise AssertionError("Didn't find Start Menu")
+    elif PLATFORM == "linux":
+        config_directory = Path(os.environ.get("XDG_CONFIG_HOME", "~/.config")).expanduser()
+        desktop_directory = (
+            Path(os.environ.get("XDG_DATA_HOME", "~/.local/share")).expanduser()
+            / "desktop-directories"
+        )
+        menu_config_location = config_directory / "menus" / "applications.menu"
+        rendered_name = f"Sys.Prefix {Path(tmp_base_path).name}"
+        slugified_name = slugify(rendered_name)
+
+        entry_file = desktop_directory / f"{slugified_name}.directory"
+        assert entry_file.exists()
+        entry = entry_file.read_text().splitlines()
+        assert f"Name={rendered_name}" in entry
+
+        tree = ElementTree.parse(menu_config_location)
+        root = tree.getroot()
+        assert rendered_name in [elt.text for elt in root.findall("Menu/Name")]
+        assert slugified_name in [elt.text for elt in root.findall("Menu/Directory")]
+        assert rendered_name in [elt.text for elt in root.finalld("Menu/Include/Category")]
 
 
 def test_precommands(delete_files):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -151,6 +151,7 @@ def test_placeholders_in_menu_name(delete_files):
         delete_files,
         "sys-prefix.json",
         expected_output=sys.prefix,
+        remove_after=False,
     )
     if PLATFORM == "win":
         for path in paths:
@@ -177,8 +178,10 @@ def test_placeholders_in_menu_name(delete_files):
         tree = ElementTree.parse(menu_config_location)
         root = tree.getroot()
         assert rendered_name in [elt.text for elt in root.findall("Menu/Name")]
-        assert slugified_name in [elt.text for elt in root.findall("Menu/Directory")]
-        assert rendered_name in [elt.text for elt in root.finalld("Menu/Include/Category")]
+        assert f"{slugified_name}.directory" in [
+            elt.text for elt in root.findall("Menu/Directory")
+        ]
+        assert rendered_name in [elt.text for elt in root.findall("Menu/Include/Category")]
 
 
 def test_precommands(delete_files):


### PR DESCRIPTION
### Description

Some menu names are not rendered for Linux shortcuts. This PR adds the the remaining instances.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?