### PR TITLE
Improve errors and warnings when shortcuts already exist

### DIFF
--- a/docs/source/defining-shortcuts.md
+++ b/docs/source/defining-shortcuts.md
@@ -19,8 +19,9 @@ four keys
         - `win`- see {class}`Windows schema <menuinst._schema.Windows>`
 
 ```{warning}
-`menuinst` will overwrite existing shortcuts, so `menu_name` and `name` must be chosen accordingly.
-Note that MacOS does not use `menu_name`.
+`menuinst` will overwrite existing shortcuts on Linux and Windows, so `menu_name` and `name` must be chosen accordingly.
+
+MacOS apps, however, will not be overwritten. Instead, `menuinst` will abort when an app with the same name exists.
 ```
 
 ```{seealso}

--- a/docs/source/defining-shortcuts.md
+++ b/docs/source/defining-shortcuts.md
@@ -18,6 +18,11 @@ four keys
         - `osx`- see {class}`MacOS schema <menuinst._schema.MacOS>`
         - `win`- see {class}`Windows schema <menuinst._schema.Windows>`
 
+```{warning}
+`menuinst` will overwrite existing shortcuts, so `menu_name` and `name` must be chosen accordingly.
+Note that MacOS does not use `menu_name`.
+```
+
 ```{seealso}
 If you want to learn more, check the {doc}`reference` for full details on the available fields and settings for each platform.
 The JSON configurations follow a well-defined schema documented at {ref}`schema`.

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -231,7 +231,7 @@ class LinuxMenuItem(MenuItem):
 
     def _write_desktop_file(self):
         if self.location.exists():
-            log.warn(f"Overwriting existing file at {self.location}.")
+            log.warning(f"Overwriting existing file at {self.location}.")
 
         lines = [
             "[Desktop Entry]",

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -233,7 +233,7 @@ class LinuxMenuItem(MenuItem):
 
     def _write_desktop_file(self):
         if self.location.exists():
-            log.warning(f"Overwriting existing file at {self.location}.")
+            log.warning("Overwriting existing file at %s.", self.location)
 
         lines = [
             "[Desktop Entry]",

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -230,6 +230,9 @@ class LinuxMenuItem(MenuItem):
         return "bash -c " + shlex.quote(" && ".join(parts))
 
     def _write_desktop_file(self):
+        if self.location.exists():
+            log.warn(f"Overwriting existing file at {self.location}.")
+
         lines = [
             "[Desktop Entry]",
             "Type=Application",

--- a/menuinst/platforms/osx.py
+++ b/menuinst/platforms/osx.py
@@ -76,7 +76,7 @@ class MacOSMenuItem(MenuItem):
     def create(self) -> Tuple[Path]:
         log.debug("Creating %s", self.location)
         if self.location.exists():
-            log.warn(f"Overwriting existing application at {self.location}.")
+            log.warning(f"Overwriting existing application at {self.location}.")
             self.remove()
         self._create_application_tree()
         self._precreate()

--- a/menuinst/platforms/osx.py
+++ b/menuinst/platforms/osx.py
@@ -75,6 +75,8 @@ class MacOSMenuItem(MenuItem):
 
     def create(self) -> Tuple[Path]:
         log.debug("Creating %s", self.location)
+        if self.location.exists():
+            self.remove()
         self._create_application_tree()
         self._precreate()
         self._copy_icon()

--- a/menuinst/platforms/osx.py
+++ b/menuinst/platforms/osx.py
@@ -76,10 +76,11 @@ class MacOSMenuItem(MenuItem):
     def create(self) -> Tuple[Path]:
         if self.location.exists():
             message = (
-                f"App already exista at {self.location}. "
+                f"App already exists at {self.location}. "
                 "Please remove the existing shortcut before installing. "
                 "If you used conda to install this package, "
-                "re-run the installation with --no-shortcuts."
+                "reinstall the package with --force-reinstall to "
+                "create the shortcut once the location is cleared."
             )
             raise RuntimeError(message)
         log.debug("Creating %s", self.location)

--- a/menuinst/platforms/osx.py
+++ b/menuinst/platforms/osx.py
@@ -76,6 +76,7 @@ class MacOSMenuItem(MenuItem):
     def create(self) -> Tuple[Path]:
         log.debug("Creating %s", self.location)
         if self.location.exists():
+            log.warn(f"Overwriting existing application at {self.location}.")
             self.remove()
         self._create_application_tree()
         self._precreate()

--- a/menuinst/platforms/osx.py
+++ b/menuinst/platforms/osx.py
@@ -74,10 +74,15 @@ class MacOSMenuItem(MenuItem):
             os.symlink(self.render(src), rendered_dest)
 
     def create(self) -> Tuple[Path]:
-        log.debug("Creating %s", self.location)
         if self.location.exists():
-            log.warning(f"Overwriting existing application at {self.location}.")
-            self.remove()
+            message = (
+                f"App already exista at {self.location}. "
+                "Please remove the existing shortcut before installing. "
+                "If you used conda to install this package, "
+                "re-run the installation with --no-shortcuts."
+            )
+            raise RuntimeError(message)
+        log.debug("Creating %s", self.location)
         self._create_application_tree()
         self._precreate()
         self._copy_icon()

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -154,6 +154,8 @@ class WindowsMenuItem(MenuItem):
             # Notice args must be passed as positional, no keywords allowed!
             # winshortcut.create_shortcut(path, description, filename, arguments="",
             #                             workdir=None, iconpath=None, iconindex=0, app_id="")
+            if target_path.exists():
+                log.warn(f"Overwriting existing link at {target_path}.")
             create_shortcut(
                 target_path,
                 self._shortcut_filename(ext=""),

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -154,7 +154,7 @@ class WindowsMenuItem(MenuItem):
             # Notice args must be passed as positional, no keywords allowed!
             # winshortcut.create_shortcut(path, description, filename, arguments="",
             #                             workdir=None, iconpath=None, iconindex=0, app_id="")
-            if Path(target_path).exists():
+            if Path(path).exists():
                 log.warn(f"Overwriting existing link at {target_path}.")
             create_shortcut(
                 target_path,

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -154,7 +154,7 @@ class WindowsMenuItem(MenuItem):
             # Notice args must be passed as positional, no keywords allowed!
             # winshortcut.create_shortcut(path, description, filename, arguments="",
             #                             workdir=None, iconpath=None, iconindex=0, app_id="")
-            if target_path.exists():
+            if Path(target_path).exists():
                 log.warn(f"Overwriting existing link at {target_path}.")
             create_shortcut(
                 target_path,

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -155,7 +155,7 @@ class WindowsMenuItem(MenuItem):
             # winshortcut.create_shortcut(path, description, filename, arguments="",
             #                             workdir=None, iconpath=None, iconindex=0, app_id="")
             if Path(path).exists():
-                log.warn(f"Overwriting existing link at {target_path}.")
+                log.warning(f"Overwriting existing link at {target_path}.")
             create_shortcut(
                 target_path,
                 self._shortcut_filename(ext=""),

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -155,7 +155,7 @@ class WindowsMenuItem(MenuItem):
             # winshortcut.create_shortcut(path, description, filename, arguments="",
             #                             workdir=None, iconpath=None, iconindex=0, app_id="")
             if Path(path).exists():
-                log.warning(f"Overwriting existing link at {target_path}.")
+                log.warning(f"Overwriting existing link at {path}.")
             create_shortcut(
                 target_path,
                 self._shortcut_filename(ext=""),

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -155,7 +155,7 @@ class WindowsMenuItem(MenuItem):
             # winshortcut.create_shortcut(path, description, filename, arguments="",
             #                             workdir=None, iconpath=None, iconindex=0, app_id="")
             if Path(path).exists():
-                log.warning(f"Overwriting existing link at {path}.")
+                log.warning("Overwriting existing link at %s.", path)
             create_shortcut(
                 target_path,
                 self._shortcut_filename(ext=""),

--- a/news/205-overwrite-shortcuts
+++ b/news/205-overwrite-shortcuts
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Overwrite MacOS applications if they already exist and warn about overwriting shortcuts on other platforms. (#203 via #205)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/205-overwrite-shortcuts
+++ b/news/205-overwrite-shortcuts
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Overwrite MacOS applications if they already exist and warn about overwriting shortcuts on other platforms. (#203 via #205)
+* Improve error handling for installing identical MacOS apps and warn about overwriting shortcuts on other platforms. (#203 via #205)
 
 ### Deprecations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,9 @@ def delete_files():
     yield paths
     for path in paths:
         path = Path(path)
+        # If the list contains duplicates, a path may already have been deleted.
+        if not path.exists():
+            continue
         try:
             if path.is_dir():
                 shutil.rmtree(path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,6 +144,19 @@ def test_install_prefix(delete_files):
     check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
 
 
+def test_overwrite_existing_shortcuts(delete_files):
+    """Test that overwriting shortcuts works without errors by running installation twice."""
+    check_output_from_shortcut(
+        delete_files,
+        "sys-prefix.json",
+        expected_output=sys.prefix,
+        remove_after=False,
+    )
+    check_output_from_shortcut(
+        delete_files, "sys-prefix.json", expected_output=sys.prefix, remove_after=True
+    )
+
+
 @pytest.mark.skipif(PLATFORM != "win", reason="Windows only")
 def test_placeholders_in_menu_name(delete_files):
     _, paths, tmp_base_path, _ = check_output_from_shortcut(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,7 +144,7 @@ def test_install_prefix(delete_files):
     check_output_from_shortcut(delete_files, "sys-prefix.json", expected_output=sys.prefix)
 
 
-def test_overwrite_existing_shortcuts(delete_files):
+def test_overwrite_existing_shortcuts(delete_files, caplog):
     """Test that overwriting shortcuts works without errors by running installation twice."""
     check_output_from_shortcut(
         delete_files,
@@ -152,9 +152,14 @@ def test_overwrite_existing_shortcuts(delete_files):
         expected_output=sys.prefix,
         remove_after=False,
     )
+    caplog.clear()
     check_output_from_shortcut(
-        delete_files, "sys-prefix.json", expected_output=sys.prefix, remove_after=True
+        delete_files,
+        "sys-prefix.json",
+        expected_output=sys.prefix,
+        remove_after=True,
     )
+    assert any(line.startswith("Overwriting existing") for line in caplog.messages)
 
 
 @pytest.mark.skipif(PLATFORM != "win", reason="Windows only")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -148,15 +148,13 @@ def test_overwrite_existing_shortcuts(delete_files, caplog):
     """Test that overwriting shortcuts works without errors by running installation twice."""
     check_output_from_shortcut(
         delete_files,
-        "sys-prefix.json",
-        expected_output=sys.prefix,
+        "precommands.json",
         remove_after=False,
     )
     caplog.clear()
     check_output_from_shortcut(
         delete_files,
-        "sys-prefix.json",
-        expected_output=sys.prefix,
+        "precommands.json",
         remove_after=True,
     )
     assert any(line.startswith("Overwriting existing") for line in caplog.messages)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -152,13 +152,21 @@ def test_overwrite_existing_shortcuts(delete_files, caplog):
         "precommands.json",
         remove_after=False,
     )
-    caplog.clear()
-    check_output_from_shortcut(
-        delete_files,
-        "precommands.json",
-        remove_after=True,
-    )
-    assert any(line.startswith("Overwriting existing") for line in caplog.messages)
+    if PLATFORM == "osx":
+        with pytest.raises(RuntimeError):
+            check_output_from_shortcut(
+                delete_files,
+                "precommands.json",
+                remove_after=True,
+            )
+    else:
+        caplog.clear()
+        check_output_from_shortcut(
+            delete_files,
+            "precommands.json",
+            remove_after=True,
+        )
+        assert any(line.startswith("Overwriting existing") for line in caplog.messages)
 
 
 @pytest.mark.skipif(PLATFORM == "osx", reason="No menu names on MacOS")


### PR DESCRIPTION
### Description

On Windows and Linux, shortcuts are overwritten when they already exist. On MacOS, menuinst exits with an error because it cannot create the Resources directory inside the app.

~Since an app is not a simple file, removing the entire directory before creating the new app is the easiest way to ensure that a proper overwrite was done. The test I fails with the current menuinst.~

I also decided to add warnings to when shortcuts are overwritten. This behavior has always been a little hidden and could cause some surprises if users are not aware of this behavior.

EDIT: after some discussion, a more prudent way is to improve the error message. Individual packages can still remove the app using pre-link features if they want to overwrite.

Closes #203.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?