### PR TITLE
Fix Windows registry access mode when adding icons to file type associations

### DIFF
--- a/menuinst/platforms/win_utils/registry.py
+++ b/menuinst/platforms/win_utils/registry.py
@@ -72,7 +72,7 @@ def register_file_extension(extension, identifier, command, icon=None, mode="use
         log.debug("Created registry entry for command '%s'", command)
 
         if icon:
-            subkey = winreg.OpenKey(key, identifier)
+            subkey = winreg.OpenKey(key, identifier, access=winreg.KEY_SET_VALUE)
             winreg.SetValueEx(subkey, "DefaultIcon", 0, winreg.REG_SZ, icon)
             log.debug("Created registry entry for icon '%s'", icon)
 

--- a/news/206-file-extensions-regkey-access
+++ b/news/206-file-extensions-regkey-access
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix Windows registry key access mode when adding icon file to file type association. (#191 via #206)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/data/jsons/file_types.json
+++ b/tests/data/jsons/file_types.json
@@ -6,7 +6,7 @@
         {
             "name": "FileTypeAssociation",
             "description": "Testing file type association",
-            "icon": null,
+            "icon": "icon.{{ ICON_EXT }}",
             "command": [
                 "{{ PYTHON }}",
                 "-c",

--- a/tests/data/jsons/file_types.json
+++ b/tests/data/jsons/file_types.json
@@ -6,7 +6,7 @@
         {
             "name": "FileTypeAssociation",
             "description": "Testing file type association",
-	    "icon": null,
+            "icon": null,
             "command": [
                 "{{ PYTHON }}",
                 "-c",

--- a/tests/data/jsons/file_types.json
+++ b/tests/data/jsons/file_types.json
@@ -6,7 +6,7 @@
         {
             "name": "FileTypeAssociation",
             "description": "Testing file type association",
-            "icon": "icon.{{ ICON_EXT }}",
+	    "icon": null,
             "command": [
                 "{{ PYTHON }}",
                 "-c",
@@ -14,6 +14,7 @@
             ],
             "platforms": {
                 "win": {
+                    "icon": "icon.{{ ICON_EXT }}",
                     "command": [
                         "{{ PYTHON }}",
                         "-c",

--- a/tests/data/jsons/file_types.json
+++ b/tests/data/jsons/file_types.json
@@ -14,7 +14,7 @@
             ],
             "platforms": {
                 "win": {
-                    "icon": "icon.{{ ICON_EXT }}",
+                    "icon": "doesnotexistbutitsok.{{ ICON_EXT }}",
                     "command": [
                         "{{ PYTHON }}",
                         "-c",


### PR DESCRIPTION
### Description

When adding an icon to a file type association in the Windows registry, the subkey is opened with read-only access. This leads to a permission error when trying to add the icon. This was not caught by tests because the data file did not have the `icon` key set.

Opening the subkey with `KEY_SET_VALUE` correctly adds the icon file.

Closes #191.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
