### PR TITLE
Expand variables for working directory and adjust Windows default path

### DIFF
--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -251,7 +251,7 @@ class LinuxMenuItem(MenuItem):
 
         working_dir = self.render_key("working_dir")
         if working_dir:
-            Path(working_dir).mkdir(parents=True, exist_ok=True)
+            Path(os.path.expandvars(working_dir)).mkdir(parents=True, exist_ok=True)
             lines.append(f"Path={working_dir}")
 
         for key in menuitem_defaults["platforms"]["linux"]:

--- a/menuinst/platforms/osx.py
+++ b/menuinst/platforms/osx.py
@@ -185,7 +185,7 @@ class MacOSMenuItem(MenuItem):
 
         working_dir = self.render_key("working_dir")
         if working_dir:
-            Path(working_dir).mkdir(parents=True, exist_ok=True)
+            Path(os.path.expandvars(working_dir)).mkdir(parents=True, exist_ok=True)
             lines.append(f'cd "{working_dir}"')
 
         precommand = self.render_key("precommand")

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -160,8 +160,14 @@ class WindowsMenuItem(MenuItem):
             working_dir = self.render_key("working_dir")
             if working_dir:
                 Path(os.path.expandvars(working_dir)).mkdir(parents=True, exist_ok=True)
+            # There are two possible interpretations of HOME on Windows:
+            # `%USERPROFILE%` and `%HOMEDRIVE%%HOMEPATH%`.
+            # Follow os.path.expanduser logic here, but keep the variables
+            # so that Windows can resolve them at runtime in case the drives change.
+            elif "USERPROFILE" in os.environ:
+                working_dir = "%USERPROFILE%"
             else:
-                working_dir = "%HOMEPATH%"
+                working_dir = "%HOMEDRIVE%%HOMEPATH%"
 
             icon = self.render_key("icon") or ""
 

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -159,7 +159,7 @@ class WindowsMenuItem(MenuItem):
             target_path, *arguments = self._process_command()
             working_dir = self.render_key("working_dir")
             if working_dir:
-                Path(working_dir).mkdir(parents=True, exist_ok=True)
+                Path(os.path.expandvars(working_dir)).mkdir(parents=True, exist_ok=True)
             else:
                 working_dir = "%HOMEPATH%"
 

--- a/news/212-improve-working-dir-handling
+++ b/news/212-improve-working-dir-handling
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Expand variables when `creating working_dir` and use `os.path.expanduser` logic for default `working_dir` on Windows. (#211 via #212)
+* Expand variables when creating `working_dir` and use `os.path.expanduser` logic for default `working_dir` on Windows. (#211 via #212)
 
 ### Deprecations
 

--- a/news/212-improve-working-dir-handling
+++ b/news/212-improve-working-dir-handling
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Expand variables when `creating working_dir` and use `os.path.expanduser` logic for default `working_dir` on Windows. (#211 via #212)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/data/jsons/sys-prefix.json
+++ b/tests/data/jsons/sys-prefix.json
@@ -19,11 +19,16 @@
                         "-c",
                         "import sys; f = open(r'__OUTPUT_FILE__', 'w'); f.write(sys.prefix); f.close()"
                     ],
-                    "description": "Note how __OUTPUT_FILE__ is using raw-strings. Otherwise the backslashes are not properly escaped."
+                    "description": "Note how __OUTPUT_FILE__ is using raw-strings. Otherwise the backslashes are not properly escaped.",
+		    "working_dir": "%TEMP%/working_dir_test"
                 },
-                "linux": {},
+                "linux": {
+		    "precommand": "export TMP=/tmp",
+		    "working_dir": "${HOME}/working_dir_test"
+		},
                 "osx": {
-                    "CFBundleName": "Sys Prefix"
+                    "CFBundleName": "Sys Prefix",
+		    "working_dir": "${TMPDIR}/working_dir_test"
                 }
             }
         }

--- a/tests/data/jsons/working-dir.json
+++ b/tests/data/jsons/working-dir.json
@@ -19,11 +19,15 @@
                         "-c",
                         "import sys; f = open(r'__OUTPUT_FILE__', 'w'); f.write(sys.prefix); f.close()"
                     ],
-                    "description": "Note how __OUTPUT_FILE__ is using raw-strings. Otherwise the backslashes are not properly escaped."
+                    "description": "Note how __OUTPUT_FILE__ is using raw-strings. Otherwise the backslashes are not properly escaped.",
+		    "working_dir": "%TEMP%/working_dir_test"
                 },
-                "linux": {},
+                "linux": {
+		    "working_dir": "${TMP}/working_dir_test"
+		},
                 "osx": {
-                    "CFBundleName": "Sys Prefix"
+                    "CFBundleName": "Sys Prefix",
+		    "working_dir": "${TMPDIR}/working_dir_test"
                 }
             }
         }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -372,3 +372,19 @@ def test_name_dictionary(target_env_is_base):
         assert item_names == expected
     finally:
         remove(abs_json_path, target_prefix=tmp_target_path, base_prefix=tmp_base_path)
+
+
+def test_vars_in_working_dir(tmp_path, delete_files):
+    if PLATFORM == "win":
+        expected_directory = Path(os.environ["TEMP"], "working_dir_test")
+    elif PLATFORM == "osx":
+        expected_directory = Path(os.environ["TMPDIR"], "working_dir_test")
+    else:
+        expected_directory = Path(os.environ["TMP"], "working_dir_test")
+    delete_files.append(expected_directory)
+    datafile = str(DATA / "jsons" / "sys-prefix.json")
+    try:
+        install(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
+        assert expected_directory.exists()
+    finally:
+        remove(datafile, base_prefix=tmp_path, target_prefix=tmp_path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -374,15 +374,17 @@ def test_name_dictionary(target_env_is_base):
         remove(abs_json_path, target_prefix=tmp_target_path, base_prefix=tmp_base_path)
 
 
-def test_vars_in_working_dir(tmp_path, delete_files):
+def test_vars_in_working_dir(tmp_path, monkeypatch, delete_files):
     if PLATFORM == "win":
         expected_directory = Path(os.environ["TEMP"], "working_dir_test")
     elif PLATFORM == "osx":
         expected_directory = Path(os.environ["TMPDIR"], "working_dir_test")
     else:
+        # Linux often does not have an environment variable for the tmp directory
+        monkeypatch.setenv("TMP", "/tmp")
         expected_directory = Path("/tmp/working_dir_test")
     delete_files.append(expected_directory)
-    datafile = str(DATA / "jsons" / "sys-prefix.json")
+    datafile = str(DATA / "jsons" / "working-dir.json")
     try:
         install(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
         assert expected_directory.exists()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -380,7 +380,7 @@ def test_vars_in_working_dir(tmp_path, delete_files):
     elif PLATFORM == "osx":
         expected_directory = Path(os.environ["TMPDIR"], "working_dir_test")
     else:
-        expected_directory = Path(os.environ["TMP"], "working_dir_test")
+        expected_directory = Path("/tmp/working_dir_test")
     delete_files.append(expected_directory)
     datafile = str(DATA / "jsons" / "sys-prefix.json")
     try:


### PR DESCRIPTION
### Description

This PR fixes two bugs:

1. Environment variables are permitted for `working_dir`, but are not expanded. If `working_dir` is set to, e.g, `%USERPROFILE%\workdir` on Windows, `menuinst` would create a literal `%USERPROFILE%\workdir` path directory instead of `%SYSTEMDRIVE%\Users\%USERNAME%\workdir`. Expand these variables to create the correct directory name.
2. The bug reported by #211. `%HOMEPATH%` alone does not contain a drive, which can fail if `%HOMEDRIVE%` is not `C:`. This PR uses a default directory that contains the drive name.

The second item is up for debate. The `menuinst` documentation describes that `working_dir` defaults to the user's home directory. On Windows, there can be two different interpretations: `%USERPROFILE%` or `%HOMEDRIVE%%HOMEPATH%`.

I decided to go with a precedent: [os.path.expanduser](https://docs.python.org/3/library/os.path.html#os.path.expanduser) checks if `%USERPROFILE%` is set and goes with `%HOMEDRIVE%%HOMEPATH%` otherwise. `pathlib.Path.home()` uses the same implementation, so I think `menuinst` should use the same definition as the Python ecosystem.

Instead of using `os.path.expanduser("~")`, I am using the names of the variables though to make the shortcuts be resolved at runtime instead of hard-coding the directories.

Closes #211 

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?