### PR TITLE
Pin Visual Studio version to 2022 for canary builds

### DIFF
--- a/news/215-vs-version-canary-builds
+++ b/news/215-vs-version-canary-builds
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Pin Visual Studio version to 2022 for canary builds to account for changes to GitHub runners. (#215)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,3 +3,8 @@ python:
   - "3.9"
   - "3.10"
   - "3.11"
+# Use VS version available on GitHub runners
+c_compiler:    # [win]
+  - vs2022     # [win]
+cxx_compiler:  # [win]
+  - vs2022     # [win]


### PR DESCRIPTION
### Description


GitHub has removed Visual Studio components recently (see https://github.com/actions/runner-images/pull/9853).

This breaks canary builds on Windows because `compiler('cxx')` selects an older version of Visual Studio. Visual Studio 2022 is available, so pinning the compiler version will allow Windows canary builds to succeed again.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?