### PR TITLE
Only delete `Menu` when empty

### DIFF
--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -65,11 +65,11 @@ class LinuxMenu(Menu):
         return (path,)
 
     def remove(self) -> Tuple[os.PathLike]:
-        unlink(self.directory_entry_location, missing_ok=True)
         for fn in os.listdir(self.desktop_entries_location):
             if fn.startswith(f"{self.render(self.name, slug=True)}_"):
                 # found one shortcut, so don't remove the name from menu
                 return (self.directory_entry_location,)
+        unlink(self.directory_entry_location, missing_ok=True)
         self._remove_this_menu()
         return (self.directory_entry_location,)
 

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -36,8 +36,12 @@ class WindowsMenu(Menu):
         return (self.start_menu_location,)
 
     def remove(self) -> Tuple[os.PathLike]:
-        log.debug("Removing %s", self.start_menu_location)
-        shutil.rmtree(self.start_menu_location, ignore_errors=True)
+        # Only remove if the Start Menu directory is empty in case applications share a folder.
+        try:
+            next(Path(self.start_menu_location).iterdir())
+        except StopIteration:
+            log.debug("Removing %s", self.start_menu_location)
+            shutil.rmtree(self.start_menu_location, ignore_errors=True)
         return (self.start_menu_location,)
 
     @property

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -37,13 +37,15 @@ class WindowsMenu(Menu):
 
     def remove(self) -> Tuple[os.PathLike]:
         # Only remove if the Start Menu directory is empty in case applications share a folder.
-        try:
-            menu_location = Path(self.start_menu_location)
-            if menu_location.exists():
+        menu_location = Path(self.start_menu_location)
+        if menu_location.exists():
+            try:
+                # Check directory contents. If empty, it will raise StopIteration
+                # and only in that case we delete the directory.
                 next(menu_location.iterdir())
-        except StopIteration:
-            log.debug("Removing %s", self.start_menu_location)
-            shutil.rmtree(self.start_menu_location, ignore_errors=True)
+            except StopIteration:
+                log.debug("Removing %s", self.start_menu_location)
+                shutil.rmtree(self.start_menu_location, ignore_errors=True)
         return (self.start_menu_location,)
 
     @property

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -38,7 +38,9 @@ class WindowsMenu(Menu):
     def remove(self) -> Tuple[os.PathLike]:
         # Only remove if the Start Menu directory is empty in case applications share a folder.
         try:
-            next(Path(self.start_menu_location).iterdir())
+            menu_location = Path(self.start_menu_location)
+            if menu_location.exists():
+                next(menu_location.iterdir())
         except StopIteration:
             log.debug("Removing %s", self.start_menu_location)
             shutil.rmtree(self.start_menu_location, ignore_errors=True)

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -348,7 +348,6 @@ class WindowsMenuItem(MenuItem):
 
         if remove:
             if index < 0:
-                log.warning(f"Could not find terminal profile for {name}.")
                 return
             del settings["profiles"]["list"][index]
         else:

--- a/news/218-only-delete-empty-menus
+++ b/news/218-only-delete-empty-menus
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Only delete menus when they do not contain any items. (#218)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

The `Menu` directories are currently removed even if multiple apps share the same folder. In other words, if two apps install into the same Start Menu directory, uninstalling one of these apps will remove the entire directory. This is a regression from `menuinst v1`.

The same behavior happens on Linux, which doesn't appear to be the intention since `_remove_this_menu()` is only called if there are no additional items in the `Menu`. The unlinking happens regardless though.

This PR ensures that the `Menu` directory is only removed if the directory associated with `Menu` are indeed empty after all `MenuItems` have been removed.

I also noticed that when removing a Windows Terminal Profile via `conda`, the message "Could not find terminal profile for {name}.", presumably because the `remove` operation is executed twice. I think that message isn't helpful in either case, so I removed it here (not worth a separate PR).

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?