### PR TITLE
Replace logger.warn w/ logger.warning

### DIFF
--- a/menuinst/_legacy/__init__.py
+++ b/menuinst/_legacy/__init__.py
@@ -80,7 +80,7 @@ def install(path, remove=False, prefix=None, recursing=False, root_prefix=None):
                 pass
 
             if retcode != 0:
-                logging.warn(
+                logging.warning(
                     "Insufficient permissions to write menu folder.  "
                     "Falling back to user location"
                 )

--- a/menuinst/_legacy/win32.py
+++ b/menuinst/_legacy/win32.py
@@ -152,7 +152,7 @@ class Menu(object):
             #   required.  If the process isn't elevated, we get the
             #   WindowsError
             if 'user' in dirs_src and used_mode == 'system':
-                logger.warn(
+                logger.warning(
                     "Insufficient permissions to write menu folder.  "
                     "Falling back to user location"
                 )

--- a/menuinst/api.py
+++ b/menuinst/api.py
@@ -154,7 +154,7 @@ def _install_adapter(
                 kwargs["root_prefix"] = DEFAULT_BASE_PREFIX
             _legacy_install(json_path, remove=remove, prefix=prefix, **kwargs)
         else:
-            log.warn(
+            log.warning(
                 "menuinst._legacy is only supported on Windows. "
                 "Switch to the new-style menu definitions "
                 "for cross-platform compatibility."

--- a/menuinst/utils.py
+++ b/menuinst/utils.py
@@ -408,7 +408,7 @@ def elevate_as_needed(func: Callable) -> Callable:
                 logger.debug("Elevating command: %s", cmd)
                 return_code = run_as_admin(cmd)
             except Exception as exc:
-                logger.warn("Elevation failed! Falling back to user mode.", exc_info=exc)
+                logger.warning("Elevation failed! Falling back to user mode.", exc_info=exc)
             else:
                 os.environ.pop("_MENUINST_RECURSING", None)
                 if return_code == 0:  # success, we are done


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This replaces calls to `logger.warn` with `logger.warning`. The former has been deprecated since Python 3.3 and generates `DeprecationWarning`s that can make output particularly in debugging and testing more noisy than necessary.

Also see conda/conda#13963.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
