### PR TITLE
Fix `xdg-mime` default registration

### DIFF
--- a/docs/source/defining-shortcuts.md
+++ b/docs/source/defining-shortcuts.md
@@ -105,9 +105,10 @@ Each operating system has a slightly different way of associating a file type to
 Unix systems have the notion of MIME types, while Windows relies more on file name extensions.
 
 - On Linux, use the `MimeType` option. Remember to add the `%f` (single file) or `%F` (several
-  files) placeholders to your command so the paths are passed adequately. If you are defining a new
-  MIME type, you must fill the `glob_patterns` field by mapping the new MIME type to the file
-  extensions you want to associate with it.
+  files) placeholders to your command so the paths are passed adequately. Otherwise, your shortcut
+  might be deemed invalid and won't show up in "Open With" menus or similar UI elements of your
+  desktop. If you are defining a new MIME type, you must fill the `glob_patterns` field by mapping
+  the new MIME type to the file extensions you want to associate with it.
 - On Windows, use `file_extensions`. Remember to add the `%1` or `%*` placeholders to your command
   so the path of the opened file(s) is passed adequately.
 - On macOS, use `CFBundleDocumentTypes`. Requires no placeholder. The opened document will be

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -290,7 +290,7 @@ class LinuxMenuItem(MenuItem):
             xdg_mime = shutil.which("xdg-mime")
             if not xdg_mime:
                 log.debug("xdg-mime not found, not registering mime types as default.")
-            logged_run([xdg_mime, "default", self.location, *mime_types])
+            logged_run([xdg_mime, "default", self.location.name, *mime_types])
 
         update_mime_database = shutil.which("update-mime-database")
         if update_mime_database:

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -302,7 +302,6 @@ class LinuxMenuItem(MenuItem):
                 if mime_type not in defaults:
                     # Do not override existing defaults
                     defaults[mime_type] = self.location.name
-                added = config["Added Associations"]
                 if mime_type in added and self.location.name not in added[mime_type]:
                     added[mime_type] = f"{added[mime_type]};{self.location.name}"
                 else:

--- a/news/227-xdg-mime-default
+++ b/news/227-xdg-mime-default
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix default MIME type registration on Linux. (#226 via #227)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #226. Instead of using `xdg-mime default`, we edit `mimeapps.list` manually. If an application is already registered as default, we won't override it. We always populate the "Added associations" list with our desktop file so it's there in the "open with" menu. We also handle cleanups now.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
