### PR TITLE
Add setuptools to host requirements

### DIFF
--- a/news/237-add-setuptools-req
+++ b/news/237-add-setuptools-req
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Add setuptools to recipe host requirements. (#237)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
   run:
     - python
 


### PR DESCRIPTION
### Description

`conda-forge` recently removed `setuptools` as a run dependency for `pip`. Add `setuptools` to the recipe's host requirements to make builds succeed with the `conda-forge` channel again.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?