### PR TITLE
Documentation: Add missing comma to base/non-base example.

### DIFF
--- a/docs/source/defining-shortcuts.md
+++ b/docs/source/defining-shortcuts.md
@@ -84,7 +84,7 @@ is "Launch Turtle (turtle)". This was the default behavior of `menuinst` version
       "name": {
         "target_environment_is_base": "Launch Turtle",
         "target_environment_is_not_base": "Launch Turtle ({{ ENV_NAME }})"
-      }
+      },
       "command": ["python", "-m", "turtle"],
       "activate": true,
       "platforms": {

--- a/news/248-environment-example-typo
+++ b/news/248-environment-example-typo
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Add missing comma to base/non-base example. (#248)
+
+### Other
+
+* <news item>


### PR DESCRIPTION
### Description

Add missing comma in the documentation for the how to create different shortcuts for base/non-base environments.

Closes #245 

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?