### PR TITLE
Backport v2 privilege elevation logic to v1

### DIFF
--- a/menuinst/_legacy/__init__.py
+++ b/menuinst/_legacy/__init__.py
@@ -59,7 +59,7 @@ def install(path, remove=False, prefix=None, recursing=False, root_prefix=None):
     if not sys.platform == 'win32':
         raise RuntimeError("menuinst._legacy is only supported on Windows.")
 
-    if exists(join(prefix, ".nonadmin")) or exists(join(root_prefix, ".nonadmin")):
+    if not exists(join(prefix, ".nonadmin")) and not exists(join(root_prefix, ".nonadmin")):
         if isUserAdmin():
             _install(path, remove, prefix, mode='system', root_prefix=root_prefix)
         else:

--- a/menuinst/_legacy/__init__.py
+++ b/menuinst/_legacy/__init__.py
@@ -7,14 +7,14 @@ from __future__ import absolute_import
 import json
 import logging
 import sys
-from os.path import abspath, basename
+from os.path import abspath, basename, exists, join
 
 try:
     from .._version import __version__
 except ImportError:
     __version__ = "dev"
 
-from ..utils import DEFAULT_BASE_PREFIX, DEFAULT_PREFIX, needs_admin, python_executable
+from ..utils import DEFAULT_BASE_PREFIX, DEFAULT_PREFIX, python_executable
 
 if sys.platform == 'win32':
     from ..platforms.win_utils.win_elevate import isUserAdmin, runAsAdmin
@@ -59,7 +59,7 @@ def install(path, remove=False, prefix=None, recursing=False, root_prefix=None):
     if not sys.platform == 'win32':
         raise RuntimeError("menuinst._legacy is only supported on Windows.")
 
-    if needs_admin(prefix, root_prefix):
+    if exists(join(prefix, ".nonadmin")) or exists(join(root_prefix, ".nonadmin")):
         if isUserAdmin():
             _install(path, remove, prefix, mode='system', root_prefix=root_prefix)
         else:

--- a/news/260-backport-v2-admin-to-v1
+++ b/news/260-backport-v2-admin-to-v1
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Backport privilege elevation logic from v2 to v1. (#260)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/260-backport-v2-admin-to-v1
+++ b/news/260-backport-v2-admin-to-v1
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Backport privilege elevation logic from v2 to v1. (#260)
+* Partially backport privilege elevation logic from v2 to v1. (#260)
 
 ### Bug fixes
 


### PR DESCRIPTION
### Description

The current menuinst legacy implementation does not work with `conda-standalone`. Trying to run `conda.exe remove -p <prefix> --all` will cause an error where menuinst cannot find the python binary. This happens when menuinst is trying to elevate privileges because it only looks for `.nonadmin` files in the `root_prefix`.

This PR backports some of the menuinst v2 logic to be more robust for conda-standalone. Note that I decided to not use the `needs_admin` function because it makes additional assumptions. Specifically, it returns `False` if the user is already admin, which is not consistent with menuinst v1 behavior.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
