### PR TITLE
Drop Python 3.8 from CI test matrix.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,14 +33,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: macos-13
             python-version: "3.11"
           - os: macos-13
             python-version: "3.10"
-          - os: macos-13
-            python-version: "3.9"
 
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 #v4.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Add Linux dependencies
         if: startsWith(matrix.os, 'ubuntu')
         run: |
+          sudo apt-get update
           sudo apt-get install libfile-mimeinfo-perl desktop-file-utils
           echo "XDG_UTILS_DEBUG_LEVEL=2" >> $GITHUB_ENV
           echo "XDG_CURRENT_DESKTOP=GNOME" >> $GITHUB_ENV

--- a/news/263-drop-py38-from-tests
+++ b/news/263-drop-py38-from-tests
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Drop Python 3.8 from the CI test matrix. (#263)


### PR DESCRIPTION
### Description

`hypothesis`, which is installed to run tests, has dropped Python 3.8 support, which leads to test failures. Drop Python 3.8 from the test matrix and bump the MacOS minimum Python version to 3.9.

Additionally, run `apt-get update` before running `apt-get install` so that `apt` finds all required packages on Ubuntu.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?