### PR TITLE
Update python versions in canary builds

### DIFF
--- a/news/236-update-python-versions-canary
+++ b/news/236-update-python-versions-canary
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Update Python versions in canary builds: remove version 3.8 and add 3.12. (#266)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,8 @@
 python:
-  - "3.8"
   - "3.9"
   - "3.10"
   - "3.11"
+  - "3.12"
 # Use VS version available on GitHub runners
 c_compiler:    # [win]
   - vs2022     # [win]


### PR DESCRIPTION
### Description

Remove Python 3.8 from canary builds and add Python 3.12.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?