### PR TITLE
Flip default value for Windows' `quicklaunch` and deprecate it

### DIFF
--- a/menuinst/_schema.py
+++ b/menuinst/_schema.py
@@ -91,7 +91,7 @@ class Windows(BasePlatformSpecific):
     desktop: Optional[bool] = True
     "Whether to create a desktop icon in addition to the Start Menu item."
     quicklaunch: Optional[bool] = False
-    "Whether to create a quick launch icon in addition to the Start Menu item."
+    "DEPRECATED. Whether to create a quick launch icon in addition to the Start Menu item."
     terminal_profile: constr(min_length=1) = None
     """
     Name of the Windows Terminal profile to create.

--- a/menuinst/_schema.py
+++ b/menuinst/_schema.py
@@ -90,7 +90,7 @@ class Windows(BasePlatformSpecific):
 
     desktop: Optional[bool] = True
     "Whether to create a desktop icon in addition to the Start Menu item."
-    quicklaunch: Optional[bool] = True
+    quicklaunch: Optional[bool] = False
     "Whether to create a quick launch icon in addition to the Start Menu item."
     terminal_profile: constr(min_length=1) = None
     """

--- a/menuinst/data/menuinst.default.json
+++ b/menuinst/data/menuinst.default.json
@@ -56,7 +56,7 @@
         },
         "win": {
           "desktop": true,
-          "quicklaunch": true,
+          "quicklaunch": false,
           "terminal_profile": null,
           "url_protocols": null,
           "file_extensions": null,

--- a/menuinst/data/menuinst.schema.json
+++ b/menuinst/data/menuinst.schema.json
@@ -606,7 +606,7 @@
         },
         "quicklaunch": {
           "title": "Quicklaunch",
-          "default": true,
+          "default": false,
           "type": "boolean"
         },
         "terminal_profile": {

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -228,6 +228,7 @@ class WindowsMenuItem(MenuItem):
         if self.metadata["desktop"]:
             extra_dirs.append(self.menu.desktop_location)
         if self.metadata["quicklaunch"] and self.menu.quick_launch_location:
+            warnings.warn("Quick launch menus are deprecated.")
             extra_dirs.append(self.menu.quick_launch_location)
 
         if extra_dirs:

--- a/news/272-quicklaunch
+++ b/news/272-quicklaunch
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* In v2-style schemas, Windows setting `quicklaunch` default value is now `false` and using it is considered deprecated. (#244 via #272)
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Closes #244 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/menuinst/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/menuinst/blob/main/CONTRIBUTING.md -->
