### PR TITLE
Add `setuptools_scm` to recipe

### DIFF
--- a/news/309-add-setuptools-scm
+++ b/news/309-add-setuptools-scm
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Add `setuptools-scm` to build recipe. (#951)
+* Add `setuptools-scm` to build recipe. (#309)

--- a/news/309-add-setuptools-scm
+++ b/news/309-add-setuptools-scm
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Add `setuptools-scm` to build recipe. (#951)

--- a/news/309-add-setuptools-scm
+++ b/news/309-add-setuptools-scm
@@ -16,4 +16,4 @@
 
 ### Other
 
-* Add `setuptools-scm` to build recipe. (#309)
+* Add `setuptools_scm` to build recipe. (#309)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,8 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=45
+    - setuptools-scm >=6.2
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - python
     - pip
     - setuptools >=45
-    - setuptools-scm >=6.2
+    - setuptools_scm >=6.2
   run:
     - python
 


### PR DESCRIPTION
### Description

The build recipe is missing `setuptools_scm`. See: https://github.com/conda/menuinst/blob/fa02b329a15346728664edc7372bd43691ca915f/pyproject.toml#L2

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?
