### PR TITLE
Remove quotes from `SETUPTOOLS_SCM_PRETEND_VERSION` recipe variable

### DIFF
--- a/news/317-remove-quotes-scm-version
+++ b/news/317-remove-quotes-scm-version
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Remove quotes around SETUPTOOLS_SCM_PRETEND_VERSION recipe variable. (#317)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
 build:
   number: 0
   script_env:
-    - SETUPTOOLS_SCM_PRETEND_VERSION="{{ GIT_DESCRIBE_TAG }}+{{ GIT_BUILD_STR }}"
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{ GIT_DESCRIBE_TAG }}+{{ GIT_BUILD_STR }}
   script:
     # Apparently these files make the post-build linkage analysis crash
     # and we should not need them on Windows


### PR DESCRIPTION
### Description

Windows keeps the quotes around the variable, which makes `setuptools_scm` fail when building from the `meta.yaml` file.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
