### PR TITLE
Remove isort+black leftovers, re-enable flake8 + isort rules

### DIFF
--- a/menuinst/platforms/osx.py
+++ b/menuinst/platforms/osx.py
@@ -326,9 +326,9 @@ class MacOSMenuItem(MenuItem):
         If that key is absent or null, we assume the app has its own listener.
 
         See:
-        - https://developer.apple.com/library/archive/documentation/Carbon/Conceptual/LaunchServicesConcepts/LSCConcepts/LSCConcepts.html  # noqa
+        - https://developer.apple.com/library/archive/documentation/Carbon/Conceptual/LaunchServicesConcepts/LSCConcepts/LSCConcepts.html
         - The source code at /src/appkit-launcher in this repository
-        """
+        """  # noqa
         return bool(self.metadata.get("event_handler"))
 
 

--- a/news/315-pre-commit
+++ b/news/315-pre-commit
@@ -16,5 +16,5 @@
 
 ### Other
 
-* Use `ruff` for linting and formatting. (#315)
+* Use `ruff` for linting and formatting. (#315, #318)
 * Check and pretty-format JSON files. (#315)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,23 +26,6 @@ where = ["."]
 include = ["menuinst*"]
 namespaces = true
 
-[tool.black]
-line-length = 99
-target-version = ['py38', 'py39', 'py310', 'py311']
-include = '\.pyi?$'
-exclude = '''
-^/(
-    (
-        menuinst/_legacy
-      | tests/_legacy
-    )/
-)
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 99
-
 [tool.pyright]
 pythonPlatform = "All"
 
@@ -50,6 +33,15 @@ pythonPlatform = "All"
 line-length = 99
 exclude = [
   "_schema.py"
+]
+
+[tool.ruff.lint]
+# see https://docs.astral.sh/ruff/rules/
+select = [
+  "E",  # pycodestyle errors (part of flake8)
+  "F",  # pyflakes (part of flake8)
+  "I",  # isort
+  "W",  # pycodestyle warnings (part of flake8)
 ]
 
 [tool.vendoring]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This is a fixup PR to https://github.com/conda/menuinst/pull/315:
* flake8 was replaced by ruff, but not all flake8 rules in ruff have been activated
* isort was replaced by ruff, but isort was not enabled in ruff

The project would also benefit from pyupgrade to be enabled via ruff. Explicitly not enabling this to keep the diff low in this PR.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/menuinst/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/menuinst/blob/main/CONTRIBUTING.md -->
