### PR TITLE
Increase Windows test timeout to 30 s

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,9 @@ jobs:
         uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 #v3.1.1
         with:
           miniforge-version: latest
-          auto-activate-base: "false"
+          # Use base environment
+          auto-activate-base: "true"
+          activate-environment: ""
 
       - name: Add dependencies
         shell: bash -el {0}
@@ -71,6 +73,7 @@ jobs:
         run: |
           conda info
           conda list
+          env | sort
 
       - shell: bash -el {0}
         name: Install menuinst
@@ -81,7 +84,6 @@ jobs:
       - shell: bash -el {0}
         name: Run test suite
         run: |
-          env | sort
           python -I -m pytest tests/ --cov-append --cov-report=xml --cov=menuinst -vvv
 
       - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 #v5.4.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,7 @@ jobs:
       - shell: bash -el {0}
         name: Run test suite
         run: |
+          env | sort
           python -I -m pytest tests/ --cov-append --cov-report=xml --cov=menuinst -vvv
 
       - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 #v5.4.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,6 @@ jobs:
         run: |
           conda info
           conda list
-          env | sort
 
       - shell: bash -el {0}
         name: Install menuinst

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 #v3.1.1
         with:
           miniforge-version: latest
+          auto-activate-base: "false"
 
       - name: Add dependencies
         shell: bash -el {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Add dependencies
         shell: bash -el {0}
         run: |
+          # Clear history in base env so there are no pins
+          echo > "$CONDA_PREFIX/conda-meta/history"
           conda install -yq --solver libmamba \
             --file tests/requirements.txt \
             python=${{ matrix.python-version }}

--- a/news/319-increase-windows-test-timeout
+++ b/news/319-increase-windows-test-timeout
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Increase timeout for Windows shortcuts tests to 30 seconds. (#319)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,7 +21,7 @@ from menuinst.platforms.osx import _lsregister
 from menuinst.utils import DEFAULT_PREFIX, logged_run, slugify
 
 
-def _poll_for_file_contents(path, timeout=10):
+def _poll_for_file_contents(path, timeout=30):
     t0 = time()
     while not os.path.isfile(path):
         sleep(1)


### PR DESCRIPTION
### Description

Increase the timeout for polling Windows tests to 30 s. Canary builds fail regularly because of a timeout error. I have done some local tests and see the same failure for one of the tests. Increasing the timeout threshold solved the issue for my local builds.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?
