### PR TITLE
Also expand parameters in lists of strings

### DIFF
--- a/menuinst/platforms/base.py
+++ b/menuinst/platforms/base.py
@@ -53,7 +53,7 @@ class Menu:
         raise NotImplementedError
 
     def render(self, value: Any, slug: bool = False, extra: dict | None = None) -> Any:
-        is_list = isinstance(value, list)
+        is_list = isinstance(value, (list, tuple))
         if not is_list:
             value = [value]
         if extra:

--- a/menuinst/platforms/base.py
+++ b/menuinst/platforms/base.py
@@ -53,17 +53,26 @@ class Menu:
         raise NotImplementedError
 
     def render(self, value: Any, slug: bool = False, extra: dict | None = None) -> Any:
-        if not hasattr(value, "replace"):
-            return value
+        is_list = isinstance(value, list)
+        if not is_list:
+            value = [value]
         if extra:
             placeholders = {**self.placeholders, **extra}
         else:
             placeholders = self.placeholders
-        for placeholder, replacement in placeholders.items():
-            value = value.replace("{{ " + placeholder + " }}", replacement)
-        if slug:
-            value = slugify(value)
-        return value
+
+        final_values = []
+        for v in value:
+            if hasattr(v, "replace"):
+                for placeholder, replacement in placeholders.items():
+                    v = v.replace("{{ " + placeholder + " }}", replacement)
+                if slug:
+                    v = slugify(v)
+            final_values.append(v)
+        if not is_list:
+            return final_values[0]
+        else:
+            return final_values
 
     def _get_distribution_name(self) -> str:
         """

--- a/news/333-render-lists
+++ b/news/333-render-lists
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* `Menu.render` now expands placeholders in lists and tuples of strings
+  instead of returning them unchanged. (#333)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -621,3 +621,19 @@ def test_malformed_json_skipped_in_process_all(tmp_path, caplog):
 
     # Check that warning was logged for malformed file
     assert any("malformed.json" in msg and "malformed JSON" in msg for msg in caplog.messages)
+
+
+def test_render_expands_placeholders_in_lists(tmp_path):
+    """`Menu.render` expands placeholders in lists/tuples of strings, not just scalars."""
+    menu = Menu("Test", prefix=str(tmp_path), base_prefix=str(tmp_path))
+    extra = {"FOO": "bar"}
+
+    # Scalar strings still work as before.
+    assert menu.render("{{ FOO }}", extra=extra) == "bar"
+
+    # Lists and tuples have placeholders expanded element-wise.
+    assert menu.render(["{{ FOO }}", "{{ FOO }}/baz"], extra=extra) == ["bar", "bar/baz"]
+    assert menu.render(("{{ FOO }}",), extra=extra) == ["bar"]
+
+    # Non-string items inside a list are returned untouched.
+    assert menu.render([1, "{{ FOO }}", None], extra=extra) == [1, "bar", None]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -646,3 +646,19 @@ def test_desktop_entry_icon(tmp_path, monkeypatch):
     item._write_desktop_file()
     expected = Path(sys.prefix) / "Menu" / "icon.png"
     assert f"Icon={expected}" in item.location.read_text().splitlines()
+
+
+def test_render_expands_placeholders_in_lists(tmp_path):
+    """`Menu.render` expands placeholders in lists/tuples of strings, not just scalars."""
+    menu = Menu("Test", prefix=str(tmp_path), base_prefix=str(tmp_path))
+    extra = {"FOO": "bar"}
+
+    # Scalar strings still work as before.
+    assert menu.render("{{ FOO }}", extra=extra) == "bar"
+
+    # Lists and tuples have placeholders expanded element-wise.
+    assert menu.render(["{{ FOO }}", "{{ FOO }}/baz"], extra=extra) == ["bar", "bar/baz"]
+    assert menu.render(("{{ FOO }}",), extra=extra) == ["bar"]
+
+    # Non-string items inside a list are returned untouched.
+    assert menu.render([1, "{{ FOO }}", None], extra=extra) == [1, "bar", None]


### PR DESCRIPTION
Previously if one had a list of strings, expressions such as {{ PREFIX }} or {{ ENV_NAME }} would not get expanded

- [ ] Add a test

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I wanted to write a command that looks like `{{ PREFIX }}/bin/my_app-{{ ENV_NAME }}` 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/menuinst/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/menuinst/blob/main/CONTRIBUTING.md -->
