### PR TITLE
Expand the ability to specify parameters by is_base or not

### DIFF
--- a/docs/source/defining-shortcuts.md
+++ b/docs/source/defining-shortcuts.md
@@ -60,22 +60,54 @@ The full list of available placeholders is available at {ref}`placeholders`.
 This is not using any customization options or advanced features. It's the bare minimum to make it
 work: a name, the command, and the target platforms.
 
-## Specifying different shortcut names for base and non-base environments
+(base-or-not)=
 
-If environments are supported, different naming schemes can be specified for installations into
-the base environment and non-base environments.
-To do this, the `name` property must be a dictionary with the keys `target_environment_is_base`
-and `target_environment_is_not_base` for installations into the base and non-base environment,
-respectively.
+## Varying a field on base vs non-base environments
 
+Some fields can take a different value depending on whether the shortcut is being installed
+into the base environment or into a named environment. To do that, give the field a dictionary
+with the keys `target_environment_is_base` and `target_environment_is_not_base` instead of a
+plain value:
 
-The example below creates a shortcut called with the name "Launch Turtle" if installed into the
+```json
+"name": {
+  "target_environment_is_base": "Launch Turtle",
+  "target_environment_is_not_base": "Launch Turtle ({{ ENV_NAME }})"
+}
+```
+
+Only the branch that applies is used, and the value it holds is what the field would normally
+take: a string for `name`, a list of strings for `command`, and so on. Placeholders are expanded
+after the branch is chosen, so each branch can use its own. The branch that does not apply may be
+omitted; leaving out the one that _does_ apply is an error.
+
+The fields that accept this form are:
+
+| Field | Applies to | Type of each branch |
+|-------|------------|---------------------|
+| `name` | all platforms | string, see {class}`menuinst._schema.TargetIsBaseConStr` |
+| `command` | all platforms | list of strings, see {class}`menuinst._schema.TargetIsBaseConList` |
+| `precommand` | all platforms | string, see {class}`menuinst._schema.TargetIsBaseConStr` |
+| `StartupWMClass` | Linux | string, see {class}`menuinst._schema.TargetIsBaseConStr` |
+| `TryExec` | Linux | string, see {class}`menuinst._schema.TargetIsBaseConStr` |
+
+Like any other field, these can also be set inside a `platforms` block, in which case the
+platform-specific value overrides the top-level one.
+
+```{note}
+This is deliberately a small, fixed set of fields rather than a general conditional mechanism.
+If you need a field that is not listed above, please open an issue describing the use case.
+```
+
+### Naming shortcuts after the environment
+
+The example below creates a shortcut named "Launch Turtle" if installed into the
 base environment. If installed into an environment called, e.g., `turtle`, the name of the shortcut
 is "Launch Turtle (turtle)". This was the default behavior of `menuinst` version 1.
 
 ```json
 {
-  "$schema": "https://schemas.conda.org/menuinst/menuinst-1-1-0.schema.json",
+  "$schema": "https://schemas.conda.org/menuinst/menuinst-1-2-0.schema.json",
   "menu_name": "Python {{ PY_VER }}",
   "menu_items": [
     {
@@ -87,6 +119,39 @@ is "Launch Turtle (turtle)". This was the default behavior of `menuinst` version
       "activate": true,
       "platforms": {
         "linux": {},
+        "osx": {},
+        "win": {}
+      }
+    }
+  ]
+}
+```
+
+### Running a different command outside the base environment
+
+The same form works for `command` and `precommand`. Here, the shortcut launches the bundled
+`turtle` demo when installed in the base environment, and the environment's own `turtle` module
+otherwise:
+
+```json
+{
+  "$schema": "https://schemas.conda.org/menuinst/menuinst-1-2-0.schema.json",
+  "menu_name": "Python {{ PY_VER }}",
+  "menu_items": [
+    {
+      "name": "Launch Turtle",
+      "command": {
+        "target_environment_is_base": ["{{ BASE_PYTHON }}", "-m", "turtledemo"],
+        "target_environment_is_not_base": ["{{ PYTHON }}", "-m", "turtle"]
+      },
+      "activate": true,
+      "platforms": {
+        "linux": {
+          "TryExec": {
+            "target_environment_is_base": "{{ BASE_PYTHON }}",
+            "target_environment_is_not_base": "{{ PYTHON }}"
+          }
+        },
         "osx": {},
         "win": {}
       }

--- a/docs/source/reference.md
+++ b/docs/source/reference.md
@@ -15,7 +15,8 @@ See Schema below for more details.
 ```{eval-rst}
 .. autopydantic_model:: menuinst._schema.MenuInstSchema
 .. autopydantic_model:: menuinst._schema.MenuItem
-.. autopydantic_model:: menuinst._schema.MenuItemNameDict
+.. autopydantic_model:: menuinst._schema.TargetIsBaseConStr
+.. autopydantic_model:: menuinst._schema.TargetIsBaseConList
 .. autopydantic_model:: menuinst._schema.Platforms
 .. autopydantic_model:: menuinst._schema.Linux
 .. autopydantic_model:: menuinst._schema.MacOS

--- a/menuinst/_schema.py
+++ b/menuinst/_schema.py
@@ -62,11 +62,11 @@ def Field(*args, **kwargs):
     return _Field(*args, **kwargs)
 
 
-class MenuItemNameDict(BaseModel):
+class TargetIsBaseConStr(BaseModel):
     """
-    Variable menu item name.
-    Use this dictionary if the menu item name depends on installation parameters
-    such as the target environment.
+    Variable that depends on whether or not the the installation is in the base env.
+
+    This can help configure the menu item on if the system is in a base environment.
     """
 
     target_environment_is_base: Optional[constr(min_length=1)] = Field(
@@ -78,6 +78,21 @@ class MenuItemNameDict(BaseModel):
         description=("Name when target environment is not the base environment."),
     )
 
+class TargetIsBaseConList(BaseModel):
+    """
+    Variable that depends on whether or not the the installation is in the base env.
+
+    This can help configure the menu item on if the system is in a base environment.
+    """
+
+    target_environment_is_base: Optional[conlist(str, min_items=1)] = Field(
+        None,
+        description=("Name when target environment is the base environment."),
+    )
+    target_environment_is_not_base: Optional[conlist(str, min_items=1)] = Field(
+        None,
+        description=("Name when target environment is not the base environment."),
+    )
 
 class BasePlatformSpecific(BaseModel):
     """
@@ -88,12 +103,12 @@ class BasePlatformSpecific(BaseModel):
     * Default value is always `None`.
     """
 
-    name: Optional[Union[constr(min_length=1), MenuItemNameDict]] = Field(
+    name: Optional[Union[constr(min_length=1), TargetIsBaseConStr]] = Field(
         None,
         description=(
             """
             The name of the menu item. Can be a dictionary if the name depends on
-            installation parameters. See `MenuItemNameDict` for details.
+            installation parameters. See `TargetIsBaseConStr` for details.
             """
         ),
     )
@@ -105,7 +120,7 @@ class BasePlatformSpecific(BaseModel):
         None,
         description=("Path to the file representing or containing the icon."),
     )
-    command: Optional[conlist(str, min_items=1)] = Field(
+    command: Optional[conlist(str, min_items=1), TargetIsBaseConList] = Field(
         None,
         description=(
             """
@@ -119,7 +134,7 @@ class BasePlatformSpecific(BaseModel):
         description=(
             """
             Working directory for the running process.
-            Defaults to user directory on each platform.
+            Defaults to user recipe/owl-mcam_viewer-menu-unix.jsondirectory on each platform.
             """
         ),
     )
@@ -322,7 +337,7 @@ class Linux(BasePlatformSpecific):
             """
         ),
     )
-    StartupWMClass: Optional[str] = Field(
+    StartupWMClass: Optional[str, TargetIsBaseConStr] = Field(
         None,
         description=(
             """
@@ -331,7 +346,7 @@ class Linux(BasePlatformSpecific):
             """
         ),
     )
-    TryExec: Optional[str] = Field(
+    TryExec: Optional[str, TargetIsBaseConStr] = Field(
         None,
         description=(
             """
@@ -349,6 +364,10 @@ class Linux(BasePlatformSpecific):
             Only needed if you define custom MIME types in `MimeType`.
             """
         ),
+    )
+    run_in_bash: Optional[bool] = Field(
+        True,
+        description=("Whether to activate the target environment before running `command`."),
     )
 
 
@@ -620,7 +639,7 @@ class Platforms(BaseModel):
 class MenuItem(BaseModel):
     "Instructions to create a menu item across operating systems."
 
-    name: Union[constr(min_length=1), MenuItemNameDict] = Field(
+    name: Union[constr(min_length=1), TargetIsBaseConStr] = Field(
         ...,
         description=(
             """
@@ -633,7 +652,7 @@ class MenuItem(BaseModel):
         ...,
         description=("A longer description of the menu item. Shown on popup messages."),
     )
-    command: conlist(str, min_items=1) = Field(
+    command: Union[conlist(str, min_items=1), TargetIsBaseConList] = Field(
         ...,
         description=(
             """

--- a/menuinst/_schema.py
+++ b/menuinst/_schema.py
@@ -23,7 +23,7 @@ from pydantic.types import conlist
 log = getLogger(__name__)
 SCHEMA_DIALECT = "http://json-schema.org/draft-07/schema#"
 # We follow schemaver
-SCHEMA_VERSION = "1-1-4"
+SCHEMA_VERSION = "1-2-0"
 SCHEMA_URL = f"https://schemas.conda.org/menuinst-{SCHEMA_VERSION}.schema.json"
 
 

--- a/menuinst/_schema.py
+++ b/menuinst/_schema.py
@@ -23,7 +23,7 @@ from pydantic.types import conlist
 log = getLogger(__name__)
 SCHEMA_DIALECT = "http://json-schema.org/draft-07/schema#"
 # We follow schemaver
-SCHEMA_VERSION = "1-1-3"
+SCHEMA_VERSION = "1-1-4"
 SCHEMA_URL = f"https://schemas.conda.org/menuinst-{SCHEMA_VERSION}.schema.json"
 
 
@@ -59,11 +59,11 @@ def Field(*args, **kwargs):
 NonEmptyString = Annotated[str, Field(min_length=1)]
 
 
-class MenuItemNameDict(BaseModel):
+class TargetIsBaseConStr(BaseModel):
     """
-    Variable menu item name.
-    Use this dictionary if the menu item name depends on installation parameters
-    such as the target environment.
+    Variable that depends on whether or not the the installation is in the base env.
+
+    This can help configure the menu item on if the system is in a base environment.
     """
 
     target_environment_is_base: Optional[NonEmptyString] = Field(
@@ -71,6 +71,23 @@ class MenuItemNameDict(BaseModel):
         description=("Name when target environment is the base environment."),
     )
     target_environment_is_not_base: Optional[NonEmptyString] = Field(
+        None,
+        description=("Name when target environment is not the base environment."),
+    )
+
+
+class TargetIsBaseConList(BaseModel):
+    """
+    Variable that depends on whether or not the the installation is in the base env.
+
+    This can help configure the menu item on if the system is in a base environment.
+    """
+
+    target_environment_is_base: Optional[conlist(str, min_length=1)] = Field(
+        None,
+        description=("Name when target environment is the base environment."),
+    )
+    target_environment_is_not_base: Optional[conlist(str, min_length=1)] = Field(
         None,
         description=("Name when target environment is not the base environment."),
     )
@@ -85,12 +102,12 @@ class BasePlatformSpecific(BaseModel):
     * Default value is always `None`.
     """
 
-    name: Optional[Union[NonEmptyString, MenuItemNameDict]] = Field(
+    name: Optional[Union[NonEmptyString, TargetIsBaseConStr]] = Field(
         None,
         description=(
             """
             The name of the menu item. Can be a dictionary if the name depends on
-            installation parameters. See `MenuItemNameDict` for details.
+            installation parameters. See `TargetIsBaseConStr` for details.
             """
         ),
     )
@@ -102,7 +119,7 @@ class BasePlatformSpecific(BaseModel):
         None,
         description=("Path to the file representing or containing the icon."),
     )
-    command: Optional[conlist(str, min_length=1)] = Field(
+    command: Optional[Union[conlist(str, min_length=1), TargetIsBaseConList]] = Field(
         None,
         description=(
             """
@@ -319,7 +336,7 @@ class Linux(BasePlatformSpecific):
             """
         ),
     )
-    StartupWMClass: Optional[str] = Field(
+    StartupWMClass: Optional[Union[str, TargetIsBaseConStr]] = Field(
         None,
         description=(
             """
@@ -328,7 +345,7 @@ class Linux(BasePlatformSpecific):
             """
         ),
     )
-    TryExec: Optional[str] = Field(
+    TryExec: Optional[Union[str, TargetIsBaseConStr]] = Field(
         None,
         description=(
             """
@@ -346,6 +363,10 @@ class Linux(BasePlatformSpecific):
             Only needed if you define custom MIME types in `MimeType`.
             """
         ),
+    )
+    run_in_bash: Optional[bool] = Field(
+        True,
+        description=("Whether to wrap `command` in a `bash -c` invocation."),
     )
 
 
@@ -661,12 +682,12 @@ class Platforms(BaseModel):
 class MenuItem(BaseModel):
     "Instructions to create a menu item across operating systems."
 
-    name: Union[NonEmptyString, MenuItemNameDict] = Field(
+    name: Union[NonEmptyString, TargetIsBaseConStr] = Field(
         ...,
         description=(
             """
             The name of the menu item. Can be a dictionary if the name depends on
-            installation parameters. See `MenuItemNameDict` for details.
+            installation parameters. See `TargetIsBaseConStr` for details.
             """
         ),
     )
@@ -674,7 +695,7 @@ class MenuItem(BaseModel):
         ...,
         description=("A longer description of the menu item. Shown on popup messages."),
     )
-    command: conlist(str, min_length=1) = Field(
+    command: Union[conlist(str, min_length=1), TargetIsBaseConList] = Field(
         ...,
         description=(
             """

--- a/menuinst/_schema.py
+++ b/menuinst/_schema.py
@@ -61,35 +61,37 @@ NonEmptyString = Annotated[str, Field(min_length=1)]
 
 class TargetIsBaseConStr(BaseModel):
     """
-    Variable that depends on whether or not the the installation is in the base env.
+    A string that depends on whether the target environment is the base environment.
 
-    This can help configure the menu item on if the system is in a base environment.
+    Only the branch that applies to the installation is used; the other one may be
+    omitted. Omitting the branch that ends up applying is an error.
     """
 
     target_environment_is_base: Optional[NonEmptyString] = Field(
         None,
-        description=("Name when target environment is the base environment."),
+        description=("Value to use when the target environment is the base environment."),
     )
     target_environment_is_not_base: Optional[NonEmptyString] = Field(
         None,
-        description=("Name when target environment is not the base environment."),
+        description=("Value to use when the target environment is not the base environment."),
     )
 
 
 class TargetIsBaseConList(BaseModel):
     """
-    Variable that depends on whether or not the the installation is in the base env.
+    A list of strings that depends on whether the target environment is the base environment.
 
-    This can help configure the menu item on if the system is in a base environment.
+    Only the branch that applies to the installation is used; the other one may be
+    omitted. Omitting the branch that ends up applying is an error.
     """
 
     target_environment_is_base: Optional[conlist(str, min_length=1)] = Field(
         None,
-        description=("Name when target environment is the base environment."),
+        description=("Value to use when the target environment is the base environment."),
     )
     target_environment_is_not_base: Optional[conlist(str, min_length=1)] = Field(
         None,
-        description=("Name when target environment is not the base environment."),
+        description=("Value to use when the target environment is not the base environment."),
     )
 
 
@@ -107,7 +109,8 @@ class BasePlatformSpecific(BaseModel):
         description=(
             """
             The name of the menu item. Can be a dictionary if the name depends on
-            installation parameters. See `TargetIsBaseConStr` for details.
+            whether the target environment is the base environment.
+            See `TargetIsBaseConStr` for details.
             """
         ),
     )
@@ -124,7 +127,9 @@ class BasePlatformSpecific(BaseModel):
         description=(
             """
             Command to run with the menu item, expressed as a
-            list of strings where each string is an argument.
+            list of strings where each string is an argument. Can be a dictionary
+            if the command depends on whether the target environment is the base
+            environment. See `TargetIsBaseConList` for details.
             """
         ),
     )
@@ -137,12 +142,14 @@ class BasePlatformSpecific(BaseModel):
             """
         ),
     )
-    precommand: Optional[NonEmptyString] = Field(
+    precommand: Optional[Union[NonEmptyString, TargetIsBaseConStr]] = Field(
         None,
         description=(
             """
             (Simple, preferrably single-line) logic to run before the command is run.
-            Runs before the environment is activated, if that applies.
+            Runs before the environment is activated, if that applies. Can be a
+            dictionary if the logic depends on whether the target environment is the
+            base environment. See `TargetIsBaseConStr` for details.
             """
         ),
     )
@@ -342,6 +349,8 @@ class Linux(BasePlatformSpecific):
             """
             Advanced. See [Startup Notification spec](
             https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/).
+            Can be a dictionary if the value depends on whether the target environment
+            is the base environment. See `TargetIsBaseConStr` for details.
             """
         ),
     )
@@ -351,7 +360,9 @@ class Linux(BasePlatformSpecific):
             """
             Filename or absolute path to an executable file on disk used to
             determine if the program is actually installed and can be run. If the test
-            fails, the shortcut might be ignored / hidden.
+            fails, the shortcut might be ignored / hidden. Can be a dictionary if the
+            value depends on whether the target environment is the base environment.
+            See `TargetIsBaseConStr` for details.
             """
         ),
     )
@@ -683,7 +694,8 @@ class MenuItem(BaseModel):
         description=(
             """
             The name of the menu item. Can be a dictionary if the name depends on
-            installation parameters. See `TargetIsBaseConStr` for details.
+            whether the target environment is the base environment.
+            See `TargetIsBaseConStr` for details.
             """
         ),
     )
@@ -696,7 +708,9 @@ class MenuItem(BaseModel):
         description=(
             """
             Command to run with the menu item, expressed as a
-            list of strings where each string is an argument.
+            list of strings where each string is an argument. Can be a dictionary
+            if the command depends on whether the target environment is the base
+            environment. See `TargetIsBaseConList` for details.
             """
         ),
     )
@@ -704,12 +718,14 @@ class MenuItem(BaseModel):
         None,
         description=("Path to the file representing or containing the icon."),
     )
-    precommand: Optional[NonEmptyString] = Field(
+    precommand: Optional[Union[NonEmptyString, TargetIsBaseConStr]] = Field(
         None,
         description=(
             """
             (Simple, preferrably single-line) logic to run before the command is run.
-            Runs before the environment is activated, if that applies.
+            Runs before the environment is activated, if that applies. Can be a
+            dictionary if the logic depends on whether the target environment is the
+            base environment. See `TargetIsBaseConStr` for details.
             """
         ),
     )

--- a/menuinst/_schema.py
+++ b/menuinst/_schema.py
@@ -364,10 +364,6 @@ class Linux(BasePlatformSpecific):
             """
         ),
     )
-    run_in_bash: Optional[bool] = Field(
-        True,
-        description=("Whether to wrap `command` in a `bash -c` invocation."),
-    )
 
 
 class MacOS(BasePlatformSpecific):

--- a/menuinst/data/menuinst-1-2-0.default.json
+++ b/menuinst/data/menuinst-1-2-0.default.json
@@ -1,0 +1,74 @@
+{
+  "menu_name": "REQUIRED",
+  "menu_items": [
+    {
+      "name": "REQUIRED",
+      "description": "REQUIRED",
+      "command": [
+        "REQUIRED"
+      ],
+      "icon": null,
+      "precommand": null,
+      "precreate": null,
+      "working_dir": null,
+      "activate": true,
+      "terminal": false,
+      "platforms": {
+        "linux": {
+          "Categories": null,
+          "DBusActivatable": null,
+          "GenericName": null,
+          "Hidden": null,
+          "Implements": null,
+          "Keywords": null,
+          "MimeType": null,
+          "NoDisplay": null,
+          "NotShowIn": null,
+          "OnlyShowIn": null,
+          "PrefersNonDefaultGPU": null,
+          "SingleMainWindow": null,
+          "StartupNotify": null,
+          "StartupWMClass": null,
+          "TryExec": null,
+          "glob_patterns": null,
+          "run_in_bash": true
+        },
+        "osx": {
+          "CFBundleDisplayName": null,
+          "CFBundleIdentifier": null,
+          "CFBundleName": null,
+          "CFBundleSpokenName": null,
+          "CFBundleVersion": null,
+          "CFBundleURLTypes": null,
+          "CFBundleDocumentTypes": null,
+          "LSApplicationCategoryType": null,
+          "LSBackgroundOnly": null,
+          "LSEnvironment": null,
+          "LSMinimumSystemVersion": null,
+          "LSMultipleInstancesProhibited": null,
+          "LSRequiresNativeExecution": null,
+          "NSAudioCaptureUsageDescription": null,
+          "NSCameraUsageDescription": null,
+          "NSMainCameraUsageDescription": null,
+          "NSMicrophoneUsageDescription": null,
+          "NSSupportsAutomaticGraphicsSwitching": null,
+          "UTExportedTypeDeclarations": null,
+          "UTImportedTypeDeclarations": null,
+          "entitlements": null,
+          "info_plist_extra": null,
+          "link_in_bundle": null,
+          "event_handler": null
+        },
+        "win": {
+          "desktop": true,
+          "quicklaunch": false,
+          "terminal_profile": null,
+          "url_protocols": null,
+          "file_extensions": null,
+          "app_user_model_id": null
+        }
+      }
+    }
+  ],
+  "$schema": "https://schemas.conda.org/menuinst-1-1-4.schema.json"
+}

--- a/menuinst/data/menuinst-1-2-0.default.json
+++ b/menuinst/data/menuinst-1-2-0.default.json
@@ -30,8 +30,7 @@
           "StartupNotify": null,
           "StartupWMClass": null,
           "TryExec": null,
-          "glob_patterns": null,
-          "run_in_bash": true
+          "glob_patterns": null
         },
         "osx": {
           "CFBundleDisplayName": null,

--- a/menuinst/data/menuinst-1-2-0.default.json
+++ b/menuinst/data/menuinst-1-2-0.default.json
@@ -69,5 +69,5 @@
       }
     }
   ],
-  "$schema": "https://schemas.conda.org/menuinst-1-1-4.schema.json"
+  "$schema": "https://schemas.conda.org/menuinst-1-2-0.schema.json"
 }

--- a/menuinst/data/menuinst-1-2-0.schema.json
+++ b/menuinst/data/menuinst-1-2-0.schema.json
@@ -162,8 +162,8 @@
             }
           ],
           "default": null,
-          "description": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
-          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "description": "The name of the menu item. Can be a dictionary if the name depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Name"
         },
         "description": {
@@ -212,8 +212,8 @@
             }
           ],
           "default": null,
-          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
-          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument. Can be a dictionary if the command depends on whether the target environment is the base environment. See `TargetIsBaseConList` for details.",
+          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument. Can be a dictionary if the command depends on whether the target environment is the base environment. See `TargetIsBaseConList` for details.",
           "title": "Command"
         },
         "working_dir": {
@@ -238,12 +238,15 @@
               "type": "string"
             },
             {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
-          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies. Can be a dictionary if the logic depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies. Can be a dictionary if the logic depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Precommand"
         },
         "precreate": {
@@ -526,8 +529,8 @@
             }
           ],
           "default": null,
-          "description": "Advanced. See [Startup Notification spec]( https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/).",
-          "markdownDescription": "Advanced. See [Startup Notification spec]( https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/).",
+          "description": "Advanced. See [Startup Notification spec]( https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/). Can be a dictionary if the value depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "Advanced. See [Startup Notification spec]( https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/). Can be a dictionary if the value depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Startupwmclass"
         },
         "TryExec": {
@@ -543,8 +546,8 @@
             }
           ],
           "default": null,
-          "description": "Filename or absolute path to an executable file on disk used to determine if the program is actually installed and can be run. If the test fails, the shortcut might be ignored / hidden.",
-          "markdownDescription": "Filename or absolute path to an executable file on disk used to determine if the program is actually installed and can be run. If the test fails, the shortcut might be ignored / hidden.",
+          "description": "Filename or absolute path to an executable file on disk used to determine if the program is actually installed and can be run. If the test fails, the shortcut might be ignored / hidden. Can be a dictionary if the value depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "Filename or absolute path to an executable file on disk used to determine if the program is actually installed and can be run. If the test fails, the shortcut might be ignored / hidden. Can be a dictionary if the value depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Tryexec"
         },
         "glob_patterns": {
@@ -588,8 +591,8 @@
             }
           ],
           "default": null,
-          "description": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
-          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "description": "The name of the menu item. Can be a dictionary if the name depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Name"
         },
         "description": {
@@ -638,8 +641,8 @@
             }
           ],
           "default": null,
-          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
-          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument. Can be a dictionary if the command depends on whether the target environment is the base environment. See `TargetIsBaseConList` for details.",
+          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument. Can be a dictionary if the command depends on whether the target environment is the base environment. See `TargetIsBaseConList` for details.",
           "title": "Command"
         },
         "working_dir": {
@@ -664,12 +667,15 @@
               "type": "string"
             },
             {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
-          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies. Can be a dictionary if the logic depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies. Can be a dictionary if the logic depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Precommand"
         },
         "precreate": {
@@ -1106,8 +1112,8 @@
               "$ref": "#/$defs/TargetIsBaseConStr"
             }
           ],
-          "description": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
-          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "description": "The name of the menu item. Can be a dictionary if the name depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Name"
         },
         "description": {
@@ -1129,8 +1135,8 @@
               "$ref": "#/$defs/TargetIsBaseConList"
             }
           ],
-          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
-          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument. Can be a dictionary if the command depends on whether the target environment is the base environment. See `TargetIsBaseConList` for details.",
+          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument. Can be a dictionary if the command depends on whether the target environment is the base environment. See `TargetIsBaseConList` for details.",
           "title": "Command"
         },
         "icon": {
@@ -1155,12 +1161,15 @@
               "type": "string"
             },
             {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
-          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies. Can be a dictionary if the logic depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies. Can be a dictionary if the logic depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Precommand"
         },
         "precreate": {
@@ -1286,8 +1295,8 @@
     },
     "TargetIsBaseConList": {
       "additionalProperties": false,
-      "description": "Variable that depends on whether or not the the installation is in the base env.\n\nThis can help configure the menu item on if the system is in a base environment.",
-      "markdownDescription": "Variable that depends on whether or not the the installation is in the base env.\n\nThis can help configure the menu item on if the system is in a base environment.",
+      "description": "A list of strings that depends on whether the target environment is the base environment.\n\nOnly the branch that applies to the installation is used; the other one may be omitted. Omitting the branch that ends up applying is an error.",
+      "markdownDescription": "A list of strings that depends on whether the target environment is the base environment.\n\nOnly the branch that applies to the installation is used; the other one may be omitted. Omitting the branch that ends up applying is an error.",
       "properties": {
         "target_environment_is_base": {
           "anyOf": [
@@ -1303,8 +1312,8 @@
             }
           ],
           "default": null,
-          "description": "Name when target environment is the base environment.",
-          "markdownDescription": "Name when target environment is the base environment.",
+          "description": "Value to use when the target environment is the base environment.",
+          "markdownDescription": "Value to use when the target environment is the base environment.",
           "title": "Target Environment Is Base"
         },
         "target_environment_is_not_base": {
@@ -1321,8 +1330,8 @@
             }
           ],
           "default": null,
-          "description": "Name when target environment is not the base environment.",
-          "markdownDescription": "Name when target environment is not the base environment.",
+          "description": "Value to use when the target environment is not the base environment.",
+          "markdownDescription": "Value to use when the target environment is not the base environment.",
           "title": "Target Environment Is Not Base"
         }
       },
@@ -1331,8 +1340,8 @@
     },
     "TargetIsBaseConStr": {
       "additionalProperties": false,
-      "description": "Variable that depends on whether or not the the installation is in the base env.\n\nThis can help configure the menu item on if the system is in a base environment.",
-      "markdownDescription": "Variable that depends on whether or not the the installation is in the base env.\n\nThis can help configure the menu item on if the system is in a base environment.",
+      "description": "A string that depends on whether the target environment is the base environment.\n\nOnly the branch that applies to the installation is used; the other one may be omitted. Omitting the branch that ends up applying is an error.",
+      "markdownDescription": "A string that depends on whether the target environment is the base environment.\n\nOnly the branch that applies to the installation is used; the other one may be omitted. Omitting the branch that ends up applying is an error.",
       "properties": {
         "target_environment_is_base": {
           "anyOf": [
@@ -1345,8 +1354,8 @@
             }
           ],
           "default": null,
-          "description": "Name when target environment is the base environment.",
-          "markdownDescription": "Name when target environment is the base environment.",
+          "description": "Value to use when the target environment is the base environment.",
+          "markdownDescription": "Value to use when the target environment is the base environment.",
           "title": "Target Environment Is Base"
         },
         "target_environment_is_not_base": {
@@ -1360,8 +1369,8 @@
             }
           ],
           "default": null,
-          "description": "Name when target environment is not the base environment.",
-          "markdownDescription": "Name when target environment is not the base environment.",
+          "description": "Value to use when the target environment is not the base environment.",
+          "markdownDescription": "Value to use when the target environment is not the base environment.",
           "title": "Target Environment Is Not Base"
         }
       },
@@ -1468,8 +1477,8 @@
             }
           ],
           "default": null,
-          "description": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
-          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "description": "The name of the menu item. Can be a dictionary if the name depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Name"
         },
         "description": {
@@ -1518,8 +1527,8 @@
             }
           ],
           "default": null,
-          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
-          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument. Can be a dictionary if the command depends on whether the target environment is the base environment. See `TargetIsBaseConList` for details.",
+          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument. Can be a dictionary if the command depends on whether the target environment is the base environment. See `TargetIsBaseConList` for details.",
           "title": "Command"
         },
         "working_dir": {
@@ -1544,12 +1553,15 @@
               "type": "string"
             },
             {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            },
+            {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
-          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies. Can be a dictionary if the logic depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies. Can be a dictionary if the logic depends on whether the target environment is the base environment. See `TargetIsBaseConStr` for details.",
           "title": "Precommand"
         },
         "precreate": {

--- a/menuinst/data/menuinst-1-2-0.schema.json
+++ b/menuinst/data/menuinst-1-2-0.schema.json
@@ -1,0 +1,1760 @@
+{
+  "$defs": {
+    "CFBundleDocumentTypesModel": {
+      "additionalProperties": false,
+      "description": "Describes a document type associated with the app.",
+      "markdownDescription": "Describes a document type associated with the app.",
+      "properties": {
+        "CFBundleTypeIconFile": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the icon image file (minus the .icns extension).",
+          "markdownDescription": "Name of the icon image file (minus the .icns extension).",
+          "title": "Cfbundletypeiconfile"
+        },
+        "CFBundleTypeName": {
+          "description": "Abstract name for this document type. Uniqueness recommended.",
+          "markdownDescription": "Abstract name for this document type. Uniqueness recommended.",
+          "title": "Cfbundletypename",
+          "type": "string"
+        },
+        "CFBundleTypeRole": {
+          "anyOf": [
+            {
+              "enum": [
+                "Editor",
+                "Viewer",
+                "Shell",
+                "None"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "This key specifies the app's role with respect to the type.",
+          "markdownDescription": "This key specifies the app's role with respect to the type.",
+          "title": "Cfbundletyperole"
+        },
+        "LSItemContentTypes": {
+          "description": "List of UTI strings defining a supported file type; e.g. for PNG files, use 'public.png'. See [UTI Reference]( https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html) for more info about the system-defined UTIs. Custom UTIs can be defined via 'UTExportedTypeDeclarations'. UTIs defined by other apps (not the system) need to be imported via 'UTImportedTypeDeclarations'.\n\nSee [Fun with UTIs](https://www.cocoanetics.com/2012/09/fun-with-uti/) for more info.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of UTI strings defining a supported file type; e.g. for PNG files, use 'public.png'. See [UTI Reference]( https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html) for more info about the system-defined UTIs. Custom UTIs can be defined via 'UTExportedTypeDeclarations'. UTIs defined by other apps (not the system) need to be imported via 'UTImportedTypeDeclarations'.\n\nSee [Fun with UTIs](https://www.cocoanetics.com/2012/09/fun-with-uti/) for more info.",
+          "title": "Lsitemcontenttypes",
+          "type": "array"
+        },
+        "LSHandlerRank": {
+          "description": "Determines how Launch Services ranks this app among the apps that declare themselves editors or viewers of files of this type.",
+          "enum": [
+            "Owner",
+            "Default",
+            "Alternate"
+          ],
+          "markdownDescription": "Determines how Launch Services ranks this app among the apps that declare themselves editors or viewers of files of this type.",
+          "title": "Lshandlerrank",
+          "type": "string"
+        }
+      },
+      "required": [
+        "CFBundleTypeName",
+        "LSItemContentTypes",
+        "LSHandlerRank"
+      ],
+      "title": "CFBundleDocumentTypesModel",
+      "type": "object"
+    },
+    "CFBundleURLTypesModel": {
+      "additionalProperties": false,
+      "description": "Describes a URL scheme associated with the app.",
+      "markdownDescription": "Describes a URL scheme associated with the app.",
+      "properties": {
+        "CFBundleTypeRole": {
+          "anyOf": [
+            {
+              "enum": [
+                "Editor",
+                "Viewer",
+                "Shell",
+                "None"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "This key specifies the app's role with respect to the URL.",
+          "markdownDescription": "This key specifies the app's role with respect to the URL.",
+          "title": "Cfbundletyperole"
+        },
+        "CFBundleURLSchemes": {
+          "description": "URL schemes / protocols handled by this type (e.g. 'mailto').",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "URL schemes / protocols handled by this type (e.g. 'mailto').",
+          "title": "Cfbundleurlschemes",
+          "type": "array"
+        },
+        "CFBundleURLName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Abstract name for this URL type. Uniqueness recommended.",
+          "markdownDescription": "Abstract name for this URL type. Uniqueness recommended.",
+          "title": "Cfbundleurlname"
+        },
+        "CFBundleURLIconFile": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the icon image file (minus the .icns extension).",
+          "markdownDescription": "Name of the icon image file (minus the .icns extension).",
+          "title": "Cfbundleurliconfile"
+        }
+      },
+      "required": [
+        "CFBundleURLSchemes"
+      ],
+      "title": "CFBundleURLTypesModel",
+      "type": "object"
+    },
+    "Linux": {
+      "additionalProperties": false,
+      "description": "Linux-specific instructions.\n\nCheck the [Desktop entry specification]( https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html) for more details.",
+      "markdownDescription": "Linux-specific instructions.\n\nCheck the [Desktop entry specification]( https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html) for more details.",
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "title": "Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A longer description of the menu item. Shown on popup messages.",
+          "markdownDescription": "A longer description of the menu item. Shown on popup messages.",
+          "title": "Description"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to the file representing or containing the icon.",
+          "markdownDescription": "Path to the file representing or containing the icon.",
+          "title": "Icon"
+        },
+        "command": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConList"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "title": "Command"
+        },
+        "working_dir": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Working directory for the running process. Defaults to user directory on each platform.",
+          "markdownDescription": "Working directory for the running process. Defaults to user directory on each platform.",
+          "title": "Working Dir"
+        },
+        "precommand": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "title": "Precommand"
+        },
+        "precreate": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Simple, preferrably single-line) logic to run before the shortcut is created.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the shortcut is created.",
+          "title": "Precreate"
+        },
+        "activate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to activate the target environment before running `command`.",
+          "markdownDescription": "Whether to activate the target environment before running `command`.",
+          "title": "Activate"
+        },
+        "terminal": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether run the program in a terminal/console or not. On Windows, it only has an effect if `activate` is true. On MacOS, the application will ignore command-line arguments.",
+          "markdownDescription": "Whether run the program in a terminal/console or not. On Windows, it only has an effect if `activate` is true. On MacOS, the application will ignore command-line arguments.",
+          "title": "Terminal"
+        },
+        "Categories": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "pattern": "^.+;$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Categories in which the entry should be shown in a menu. See 'Registered categories' in the [Menu Spec]( http://www.freedesktop.org/Standards/menu-spec).",
+          "markdownDescription": "Categories in which the entry should be shown in a menu. See 'Registered categories' in the [Menu Spec]( http://www.freedesktop.org/Standards/menu-spec).",
+          "title": "Categories"
+        },
+        "DBusActivatable": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A boolean value specifying if D-Bus activation is supported for this application.",
+          "markdownDescription": "A boolean value specifying if D-Bus activation is supported for this application.",
+          "title": "Dbusactivatable"
+        },
+        "GenericName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Generic name of the application; e.g. if the name is 'conda', this would be 'Package Manager'.",
+          "markdownDescription": "Generic name of the application; e.g. if the name is 'conda', this would be 'Package Manager'.",
+          "title": "Genericname"
+        },
+        "Hidden": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Disable shortcut, signaling a missing resource.",
+          "markdownDescription": "Disable shortcut, signaling a missing resource.",
+          "title": "Hidden"
+        },
+        "Implements": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "pattern": "^.+;$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of supported interfaces. See 'Interfaces' in [Desktop Entry Spec]( https://specifications.freedesktop.org/desktop-entry-spec/latest/interfaces.html).",
+          "markdownDescription": "List of supported interfaces. See 'Interfaces' in [Desktop Entry Spec]( https://specifications.freedesktop.org/desktop-entry-spec/latest/interfaces.html).",
+          "title": "Implements"
+        },
+        "Keywords": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "pattern": "^.+;$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Additional terms to describe this shortcut to aid in searching.",
+          "markdownDescription": "Additional terms to describe this shortcut to aid in searching.",
+          "title": "Keywords"
+        },
+        "MimeType": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "pattern": "^.+;$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The MIME type(s) supported by this application. Note this includes file types and URL protocols. For URL protocols, use `x-scheme-handler/your-protocol-here`. For example, if you want to register `menuinst:`, you would include `x-scheme-handler/menuinst`.",
+          "markdownDescription": "The MIME type(s) supported by this application. Note this includes file types and URL protocols. For URL protocols, use `x-scheme-handler/your-protocol-here`. For example, if you want to register `menuinst:`, you would include `x-scheme-handler/menuinst`.",
+          "title": "Mimetype"
+        },
+        "NoDisplay": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Do not show this item in the menu. Useful to associate MIME types and other registrations, without having an actual clickable item. Not to be confused with 'Hidden'.",
+          "markdownDescription": "Do not show this item in the menu. Useful to associate MIME types and other registrations, without having an actual clickable item. Not to be confused with 'Hidden'.",
+          "title": "Nodisplay"
+        },
+        "NotShowIn": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "pattern": "^.+;$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desktop environments that should NOT display this item. It'll check against `$XDG_CURRENT_DESKTOP`.",
+          "markdownDescription": "Desktop environments that should NOT display this item. It'll check against `$XDG_CURRENT_DESKTOP`.",
+          "title": "Notshowin"
+        },
+        "OnlyShowIn": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "pattern": "^.+;$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Desktop environments that should display this item. It'll check against `$XDG_CURRENT_DESKTOP`.",
+          "markdownDescription": "Desktop environments that should display this item. It'll check against `$XDG_CURRENT_DESKTOP`.",
+          "title": "Onlyshowin"
+        },
+        "PrefersNonDefaultGPU": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Hint that the app prefers to be run on a more powerful discrete GPU if available.",
+          "markdownDescription": "Hint that the app prefers to be run on a more powerful discrete GPU if available.",
+          "title": "Prefersnondefaultgpu"
+        },
+        "SingleMainWindow": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Do not show the 'New Window' option in the app's context menu.",
+          "markdownDescription": "Do not show the 'New Window' option in the app's context menu.",
+          "title": "Singlemainwindow"
+        },
+        "StartupNotify": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Advanced. See [Startup Notification spec]( https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/).",
+          "markdownDescription": "Advanced. See [Startup Notification spec]( https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/).",
+          "title": "Startupnotify"
+        },
+        "StartupWMClass": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Advanced. See [Startup Notification spec]( https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/).",
+          "markdownDescription": "Advanced. See [Startup Notification spec]( https://www.freedesktop.org/wiki/Specifications/startup-notification-spec/).",
+          "title": "Startupwmclass"
+        },
+        "TryExec": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Filename or absolute path to an executable file on disk used to determine if the program is actually installed and can be run. If the test fails, the shortcut might be ignored / hidden.",
+          "markdownDescription": "Filename or absolute path to an executable file on disk used to determine if the program is actually installed and can be run. If the test fails, the shortcut might be ignored / hidden.",
+          "title": "Tryexec"
+        },
+        "glob_patterns": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "pattern": ".*\\*.*",
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Map of custom MIME types to their corresponding glob patterns (e.g. `*.txt`). Only needed if you define custom MIME types in `MimeType`.",
+          "markdownDescription": "Map of custom MIME types to their corresponding glob patterns (e.g. `*.txt`). Only needed if you define custom MIME types in `MimeType`.",
+          "title": "Glob Patterns"
+        },
+        "run_in_bash": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "description": "Whether to wrap `command` in a `bash -c` invocation.",
+          "markdownDescription": "Whether to wrap `command` in a `bash -c` invocation.",
+          "title": "Run In Bash"
+        }
+      },
+      "title": "Linux",
+      "type": "object"
+    },
+    "MacOS": {
+      "additionalProperties": false,
+      "description": "Mac-specific instructions. Check these URLs for more info:\n\n- `CF*` keys: see [Core Foundation Keys](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html) - `LS*` keys: see [Launch Services Keys](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html) - `entitlements`: see [Entitlements documentation](https://developer.apple.com/documentation/bundleresources/entitlements)",
+      "markdownDescription": "Mac-specific instructions. Check these URLs for more info:\n\n- `CF*` keys: see [Core Foundation Keys](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html) - `LS*` keys: see [Launch Services Keys](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html) - `entitlements`: see [Entitlements documentation](https://developer.apple.com/documentation/bundleresources/entitlements)",
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "title": "Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A longer description of the menu item. Shown on popup messages.",
+          "markdownDescription": "A longer description of the menu item. Shown on popup messages.",
+          "title": "Description"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to the file representing or containing the icon.",
+          "markdownDescription": "Path to the file representing or containing the icon.",
+          "title": "Icon"
+        },
+        "command": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConList"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "title": "Command"
+        },
+        "working_dir": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Working directory for the running process. Defaults to user directory on each platform.",
+          "markdownDescription": "Working directory for the running process. Defaults to user directory on each platform.",
+          "title": "Working Dir"
+        },
+        "precommand": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "title": "Precommand"
+        },
+        "precreate": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Simple, preferrably single-line) logic to run before the shortcut is created.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the shortcut is created.",
+          "title": "Precreate"
+        },
+        "activate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to activate the target environment before running `command`.",
+          "markdownDescription": "Whether to activate the target environment before running `command`.",
+          "title": "Activate"
+        },
+        "terminal": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether run the program in a terminal/console or not. On Windows, it only has an effect if `activate` is true. On MacOS, the application will ignore command-line arguments.",
+          "markdownDescription": "Whether run the program in a terminal/console or not. On Windows, it only has an effect if `activate` is true. On MacOS, the application will ignore command-line arguments.",
+          "title": "Terminal"
+        },
+        "CFBundleDisplayName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Display name of the bundle, visible to users and used by Siri. If not provided, 'menuinst' will use the 'name' field.",
+          "markdownDescription": "Display name of the bundle, visible to users and used by Siri. If not provided, 'menuinst' will use the 'name' field.",
+          "title": "Cfbundledisplayname"
+        },
+        "CFBundleIdentifier": {
+          "anyOf": [
+            {
+              "pattern": "^[A-z0-9\\-\\.]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Unique identifier for the shortcut. Typically uses a reverse-DNS format. If not provided, 'menuinst' will generate one from the 'name' field.",
+          "markdownDescription": "Unique identifier for the shortcut. Typically uses a reverse-DNS format. If not provided, 'menuinst' will generate one from the 'name' field.",
+          "title": "Cfbundleidentifier"
+        },
+        "CFBundleName": {
+          "anyOf": [
+            {
+              "maxLength": 16,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Short name of the bundle. May be used if `CFBundleDisplayName` is absent. If not provided, 'menuinst' will generate one from the 'name' field.",
+          "markdownDescription": "Short name of the bundle. May be used if `CFBundleDisplayName` is absent. If not provided, 'menuinst' will generate one from the 'name' field.",
+          "title": "Cfbundlename"
+        },
+        "CFBundleSpokenName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Suitable replacement for text-to-speech operations on the app. For example, 'my app one two three' instead of 'MyApp123'.",
+          "markdownDescription": "Suitable replacement for text-to-speech operations on the app. For example, 'my app one two three' instead of 'MyApp123'.",
+          "title": "Cfbundlespokenname"
+        },
+        "CFBundleVersion": {
+          "anyOf": [
+            {
+              "pattern": "^\\S+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Build version number for the bundle. In the context of 'menuinst' this can be used to signal a new version of the menu item for the same application version.",
+          "markdownDescription": "Build version number for the bundle. In the context of 'menuinst' this can be used to signal a new version of the menu item for the same application version.",
+          "title": "Cfbundleversion"
+        },
+        "CFBundleURLTypes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/CFBundleURLTypesModel"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL types supported by this app. Requires macOS 10.14.4 or above. Refer to `event_handler` if your application does not have support for Apple Events handling.",
+          "markdownDescription": "URL types supported by this app. Requires macOS 10.14.4 or above. Refer to `event_handler` if your application does not have support for Apple Events handling.",
+          "title": "Cfbundleurltypes"
+        },
+        "CFBundleDocumentTypes": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/CFBundleDocumentTypesModel"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Document types supported by this app. Requires macOS 10.14.4 or above. Refer to `event_handler` if your application does not have support for Apple Events handling.",
+          "markdownDescription": "Document types supported by this app. Requires macOS 10.14.4 or above. Refer to `event_handler` if your application does not have support for Apple Events handling.",
+          "title": "Cfbundledocumenttypes"
+        },
+        "LSApplicationCategoryType": {
+          "anyOf": [
+            {
+              "pattern": "^public\\.app-category\\.\\S+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The App Store uses this string to determine the appropriate categorization.",
+          "markdownDescription": "The App Store uses this string to determine the appropriate categorization.",
+          "title": "Lsapplicationcategorytype"
+        },
+        "LSBackgroundOnly": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Specifies whether this app runs only in the background.",
+          "markdownDescription": "Specifies whether this app runs only in the background.",
+          "title": "Lsbackgroundonly"
+        },
+        "LSEnvironment": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of key-value pairs used to define environment variables.",
+          "markdownDescription": "List of key-value pairs used to define environment variables.",
+          "title": "Lsenvironment"
+        },
+        "LSMinimumSystemVersion": {
+          "anyOf": [
+            {
+              "pattern": "^\\d+\\.\\d+\\.\\d+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Minimum version of macOS required for this app to run, as `x.y.z`. For example, for macOS v10.4 and later, use `10.4.0`.",
+          "markdownDescription": "Minimum version of macOS required for this app to run, as `x.y.z`. For example, for macOS v10.4 and later, use `10.4.0`.",
+          "title": "Lsminimumsystemversion"
+        },
+        "LSMultipleInstancesProhibited": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether an app is prohibited from running simultaneously in multiple user sessions.",
+          "markdownDescription": "Whether an app is prohibited from running simultaneously in multiple user sessions.",
+          "title": "Lsmultipleinstancesprohibited"
+        },
+        "LSRequiresNativeExecution": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If true, prevent a universal binary from being run under Rosetta emulation on an Intel-based Mac.",
+          "markdownDescription": "If true, prevent a universal binary from being run under Rosetta emulation on an Intel-based Mac.",
+          "title": "Lsrequiresnativeexecution"
+        },
+        "NSAudioCaptureUsageDescription": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A message describing why an app is requesting access to capture system audio.",
+          "markdownDescription": "A message describing why an app is requesting access to capture system audio.",
+          "title": "Nsaudiocaptureusagedescription"
+        },
+        "NSCameraUsageDescription": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A message describing why an app is requesting access to the device's camera.",
+          "markdownDescription": "A message describing why an app is requesting access to the device's camera.",
+          "title": "Nscamerausagedescription"
+        },
+        "NSMainCameraUsageDescription": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A message describing why an app is requesting access to the device's main camera.",
+          "markdownDescription": "A message describing why an app is requesting access to the device's main camera.",
+          "title": "Nsmaincamerausagedescription"
+        },
+        "NSMicrophoneUsageDescription": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A message describing why an app is requesting access to the device's microphone.",
+          "markdownDescription": "A message describing why an app is requesting access to the device's microphone.",
+          "title": "Nsmicrophoneusagedescription"
+        },
+        "NSSupportsAutomaticGraphicsSwitching": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If true, allows an OpenGL app to utilize the integrated GPU.",
+          "markdownDescription": "If true, allows an OpenGL app to utilize the integrated GPU.",
+          "title": "Nssupportsautomaticgraphicsswitching"
+        },
+        "UTExportedTypeDeclarations": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/UTTypeDeclarationModel"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The uniform type identifiers owned and exported by the app.",
+          "markdownDescription": "The uniform type identifiers owned and exported by the app.",
+          "title": "Utexportedtypedeclarations"
+        },
+        "UTImportedTypeDeclarations": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/UTTypeDeclarationModel"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The uniform type identifiers inherently supported, but not owned, by the app.",
+          "markdownDescription": "The uniform type identifiers inherently supported, but not owned, by the app.",
+          "title": "Utimportedtypedeclarations"
+        },
+        "entitlements": {
+          "anyOf": [
+            {
+              "items": {
+                "pattern": "[a-z0-9\\.\\-]+",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of permissions to request for the launched application. See [the entitlements docs]( https://developer.apple.com/documentation/bundleresources/entitlements) for a full list of possible values.",
+          "markdownDescription": "List of permissions to request for the launched application. See [the entitlements docs]( https://developer.apple.com/documentation/bundleresources/entitlements) for a full list of possible values.",
+          "title": "Entitlements"
+        },
+        "info_plist_extra": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "propertyNames": {
+                "minLength": 1
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Set of extra properties for the Info.plist file. These properties are not validated by `menuinst.`",
+          "markdownDescription": "Set of extra properties for the Info.plist file. These properties are not validated by `menuinst.`",
+          "title": "Info Plist Extra"
+        },
+        "link_in_bundle": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "pattern": "^[^/]+.*",
+                "type": "string"
+              },
+              "propertyNames": {
+                "minLength": 1
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Paths that should be symlinked into the shortcut app bundle. It takes a mapping of source to destination paths. Destination paths must be relative. Placeholder `{{ MENU_ITEM_LOCATION }}` can be useful.",
+          "markdownDescription": "Paths that should be symlinked into the shortcut app bundle. It takes a mapping of source to destination paths. Destination paths must be relative. Placeholder `{{ MENU_ITEM_LOCATION }}` can be useful.",
+          "title": "Link In Bundle"
+        },
+        "event_handler": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Required shell script logic to handle opened URL payloads. Note this feature requires macOS 10.14.4 or above. Using this key will inject a custom Swift launcher in the `.app` bundle to listen to Apple Events and forward them to your application. If your app is already handling Apple Events (e.g. via Qt's `QFileOpenEvent`), you do not need this.",
+          "markdownDescription": "Required shell script logic to handle opened URL payloads. Note this feature requires macOS 10.14.4 or above. Using this key will inject a custom Swift launcher in the `.app` bundle to listen to Apple Events and forward them to your application. If your app is already handling Apple Events (e.g. via Qt's `QFileOpenEvent`), you do not need this.",
+          "title": "Event Handler"
+        }
+      },
+      "title": "MacOS",
+      "type": "object"
+    },
+    "MenuItem": {
+      "additionalProperties": false,
+      "description": "Instructions to create a menu item across operating systems.",
+      "markdownDescription": "Instructions to create a menu item across operating systems.",
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            }
+          ],
+          "description": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "title": "Name"
+        },
+        "description": {
+          "description": "A longer description of the menu item. Shown on popup messages.",
+          "markdownDescription": "A longer description of the menu item. Shown on popup messages.",
+          "title": "Description",
+          "type": "string"
+        },
+        "command": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConList"
+            }
+          ],
+          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "title": "Command"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to the file representing or containing the icon.",
+          "markdownDescription": "Path to the file representing or containing the icon.",
+          "title": "Icon"
+        },
+        "precommand": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "title": "Precommand"
+        },
+        "precreate": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Simple, preferrably single-line) logic to run before the shortcut is created.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the shortcut is created.",
+          "title": "Precreate"
+        },
+        "working_dir": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Working directory for the running process. Defaults to user directory on each platform.",
+          "markdownDescription": "Working directory for the running process. Defaults to user directory on each platform.",
+          "title": "Working Dir"
+        },
+        "activate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "description": "Whether to activate the target environment before running `command`.",
+          "markdownDescription": "Whether to activate the target environment before running `command`.",
+          "title": "Activate"
+        },
+        "terminal": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "Whether run the program in a terminal/console or not. On Windows, it only has an effect if `activate` is true. On MacOS, the application will ignore command-line arguments.",
+          "markdownDescription": "Whether run the program in a terminal/console or not. On Windows, it only has an effect if `activate` is true. On MacOS, the application will ignore command-line arguments.",
+          "title": "Terminal"
+        },
+        "platforms": {
+          "$ref": "#/$defs/Platforms",
+          "description": "Platform-specific options. Presence of a platform field enables menu items in that platform.",
+          "markdownDescription": "Platform-specific options. Presence of a platform field enables menu items in that platform."
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "command",
+        "platforms"
+      ],
+      "title": "MenuItem",
+      "type": "object"
+    },
+    "Platforms": {
+      "additionalProperties": false,
+      "description": "Platform specific options.\n\nNote each of these fields supports the same keys as the top-level `MenuItem` (sans `platforms` itself), in case overrides are needed.",
+      "markdownDescription": "Platform specific options.\n\nNote each of these fields supports the same keys as the top-level `MenuItem` (sans `platforms` itself), in case overrides are needed.",
+      "properties": {
+        "linux": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Linux"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Options for Linux. See `Linux` model for details.",
+          "markdownDescription": "Options for Linux. See `Linux` model for details."
+        },
+        "osx": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MacOS"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Options for macOS. See `MacOS` model for details.",
+          "markdownDescription": "Options for macOS. See `MacOS` model for details."
+        },
+        "win": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Windows"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Options for Windows. See `Windows` model for details.",
+          "markdownDescription": "Options for Windows. See `Windows` model for details."
+        }
+      },
+      "title": "Platforms",
+      "type": "object"
+    },
+    "TargetIsBaseConList": {
+      "additionalProperties": false,
+      "description": "Variable that depends on whether or not the the installation is in the base env.\n\nThis can help configure the menu item on if the system is in a base environment.",
+      "markdownDescription": "Variable that depends on whether or not the the installation is in the base env.\n\nThis can help configure the menu item on if the system is in a base environment.",
+      "properties": {
+        "target_environment_is_base": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name when target environment is the base environment.",
+          "markdownDescription": "Name when target environment is the base environment.",
+          "title": "Target Environment Is Base"
+        },
+        "target_environment_is_not_base": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name when target environment is not the base environment.",
+          "markdownDescription": "Name when target environment is not the base environment.",
+          "title": "Target Environment Is Not Base"
+        }
+      },
+      "title": "TargetIsBaseConList",
+      "type": "object"
+    },
+    "TargetIsBaseConStr": {
+      "additionalProperties": false,
+      "description": "Variable that depends on whether or not the the installation is in the base env.\n\nThis can help configure the menu item on if the system is in a base environment.",
+      "markdownDescription": "Variable that depends on whether or not the the installation is in the base env.\n\nThis can help configure the menu item on if the system is in a base environment.",
+      "properties": {
+        "target_environment_is_base": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name when target environment is the base environment.",
+          "markdownDescription": "Name when target environment is the base environment.",
+          "title": "Target Environment Is Base"
+        },
+        "target_environment_is_not_base": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name when target environment is not the base environment.",
+          "markdownDescription": "Name when target environment is not the base environment.",
+          "title": "Target Environment Is Not Base"
+        }
+      },
+      "title": "TargetIsBaseConStr",
+      "type": "object"
+    },
+    "UTTypeDeclarationModel": {
+      "additionalProperties": false,
+      "properties": {
+        "UTTypeConformsTo": {
+          "description": "The Uniform Type Identifier types that this type conforms to.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "The Uniform Type Identifier types that this type conforms to.",
+          "title": "Uttypeconformsto",
+          "type": "array"
+        },
+        "UTTypeDescription": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A description for this type.",
+          "markdownDescription": "A description for this type.",
+          "title": "Uttypedescription"
+        },
+        "UTTypeIconFile": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The bundle icon resource to associate with this type.",
+          "markdownDescription": "The bundle icon resource to associate with this type.",
+          "title": "Uttypeiconfile"
+        },
+        "UTTypeIdentifier": {
+          "description": "The Uniform Type Identifier to assign to this type.",
+          "markdownDescription": "The Uniform Type Identifier to assign to this type.",
+          "title": "Uttypeidentifier",
+          "type": "string"
+        },
+        "UTTypeReferenceURL": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The webpage for a reference document that describes this type.",
+          "markdownDescription": "The webpage for a reference document that describes this type.",
+          "title": "Uttypereferenceurl"
+        },
+        "UTTypeTagSpecification": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": "A dictionary defining one or more equivalent type identifiers.",
+          "markdownDescription": "A dictionary defining one or more equivalent type identifiers.",
+          "title": "Uttypetagspecification",
+          "type": "object"
+        }
+      },
+      "required": [
+        "UTTypeConformsTo",
+        "UTTypeIdentifier",
+        "UTTypeTagSpecification"
+      ],
+      "title": "UTTypeDeclarationModel",
+      "type": "object"
+    },
+    "Windows": {
+      "additionalProperties": false,
+      "description": "Windows-specific instructions. You can override global keys here if needed",
+      "markdownDescription": "Windows-specific instructions. You can override global keys here if needed",
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConStr"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "markdownDescription": "The name of the menu item. Can be a dictionary if the name depends on installation parameters. See `TargetIsBaseConStr` for details.",
+          "title": "Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A longer description of the menu item. Shown on popup messages.",
+          "markdownDescription": "A longer description of the menu item. Shown on popup messages.",
+          "title": "Description"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to the file representing or containing the icon.",
+          "markdownDescription": "Path to the file representing or containing the icon.",
+          "title": "Icon"
+        },
+        "command": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            {
+              "$ref": "#/$defs/TargetIsBaseConList"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "markdownDescription": "Command to run with the menu item, expressed as a list of strings where each string is an argument.",
+          "title": "Command"
+        },
+        "working_dir": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Working directory for the running process. Defaults to user directory on each platform.",
+          "markdownDescription": "Working directory for the running process. Defaults to user directory on each platform.",
+          "title": "Working Dir"
+        },
+        "precommand": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the command is run. Runs before the environment is activated, if that applies.",
+          "title": "Precommand"
+        },
+        "precreate": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Simple, preferrably single-line) logic to run before the shortcut is created.",
+          "markdownDescription": "(Simple, preferrably single-line) logic to run before the shortcut is created.",
+          "title": "Precreate"
+        },
+        "activate": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether to activate the target environment before running `command`.",
+          "markdownDescription": "Whether to activate the target environment before running `command`.",
+          "title": "Activate"
+        },
+        "terminal": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether run the program in a terminal/console or not. On Windows, it only has an effect if `activate` is true. On MacOS, the application will ignore command-line arguments.",
+          "markdownDescription": "Whether run the program in a terminal/console or not. On Windows, it only has an effect if `activate` is true. On MacOS, the application will ignore command-line arguments.",
+          "title": "Terminal"
+        },
+        "desktop": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "description": "Whether to create a desktop icon in addition to the Start Menu item.",
+          "markdownDescription": "Whether to create a desktop icon in addition to the Start Menu item.",
+          "title": "Desktop"
+        },
+        "quicklaunch": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "deprecated": true,
+          "description": "DEPRECATED. Whether to create a quick launch icon in addition to the Start Menu item.",
+          "markdownDescription": "DEPRECATED. Whether to create a quick launch icon in addition to the Start Menu item.",
+          "title": "Quicklaunch"
+        },
+        "terminal_profile": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of the Windows Terminal profile to create. This name must be unique across multiple installations because menuinst will overwrite Terminal profiles with the same name.",
+          "markdownDescription": "Name of the Windows Terminal profile to create. This name must be unique across multiple installations because menuinst will overwrite Terminal profiles with the same name.",
+          "title": "Terminal Profile"
+        },
+        "url_protocols": {
+          "anyOf": [
+            {
+              "items": {
+                "pattern": "\\S+",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL protocols that will be associated with this program.",
+          "markdownDescription": "URL protocols that will be associated with this program.",
+          "title": "Url Protocols"
+        },
+        "file_extensions": {
+          "anyOf": [
+            {
+              "items": {
+                "pattern": "\\.\\S*",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "File extensions that will be associated with this program.",
+          "markdownDescription": "File extensions that will be associated with this program.",
+          "title": "File Extensions"
+        },
+        "app_user_model_id": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "pattern": "\\S+\\.\\S+",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Identifier used in Windows 7 and above to associate processes, files and windows with a particular application. If your shortcut produces duplicated icons, you need to define this field. If not set, it will default to `Menuinst.<name>`.\n\nSee [AppUserModelID docs]( https://learn.microsoft.com/en-us/windows/win32/shell/appids#how-to-form-an-application-defined-appusermodelid) for more information on the required string format.",
+          "markdownDescription": "Identifier used in Windows 7 and above to associate processes, files and windows with a particular application. If your shortcut produces duplicated icons, you need to define this field. If not set, it will default to `Menuinst.<name>`.\n\nSee [AppUserModelID docs]( https://learn.microsoft.com/en-us/windows/win32/shell/appids#how-to-form-an-application-defined-appusermodelid) for more information on the required string format.",
+          "title": "App User Model Id"
+        }
+      },
+      "title": "Windows",
+      "type": "object"
+    }
+  },
+  "$id": "https://schemas.conda.org/menuinst-1-1-4.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$version": "1-1-4",
+  "additionalProperties": false,
+  "description": "Metadata required to create menu items across operating systems with `menuinst`.",
+  "properties": {
+    "$id": {
+      "default": "https://schemas.conda.org/menuinst-1-1-4.schema.json",
+      "deprecated": true,
+      "description": "DEPRECATED. Use ``$schema``.",
+      "markdownDescription": "DEPRECATED. Use ``$schema``.",
+      "minLength": 1,
+      "title": "$Id",
+      "type": "string"
+    },
+    "$schema": {
+      "default": "https://schemas.conda.org/menuinst-1-1-4.schema.json",
+      "description": "Version of the menuinst schema to validate against.",
+      "markdownDescription": "Version of the menuinst schema to validate against.",
+      "minLength": 1,
+      "title": "$Schema",
+      "type": "string"
+    },
+    "menu_name": {
+      "description": "Name for the category containing the items specified in `menu_items`.",
+      "markdownDescription": "Name for the category containing the items specified in `menu_items`.",
+      "minLength": 1,
+      "title": "Menu Name",
+      "type": "string"
+    },
+    "menu_items": {
+      "description": "List of menu entries to create across main desktop systems.",
+      "items": {
+        "$ref": "#/$defs/MenuItem"
+      },
+      "markdownDescription": "List of menu entries to create across main desktop systems.",
+      "minItems": 1,
+      "title": "Menu Items",
+      "type": "array"
+    }
+  },
+  "required": [
+    "menu_name",
+    "menu_items"
+  ],
+  "title": "MenuInstSchema",
+  "type": "object"
+}

--- a/menuinst/data/menuinst-1-2-0.schema.json
+++ b/menuinst/data/menuinst-1-2-0.schema.json
@@ -1696,14 +1696,14 @@
       "type": "object"
     }
   },
-  "$id": "https://schemas.conda.org/menuinst-1-1-4.schema.json",
+  "$id": "https://schemas.conda.org/menuinst-1-2-0.schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$version": "1-1-4",
+  "$version": "1-2-0",
   "additionalProperties": false,
   "description": "Metadata required to create menu items across operating systems with `menuinst`.",
   "properties": {
     "$id": {
-      "default": "https://schemas.conda.org/menuinst-1-1-4.schema.json",
+      "default": "https://schemas.conda.org/menuinst-1-2-0.schema.json",
       "deprecated": true,
       "description": "DEPRECATED. Use ``$schema``.",
       "markdownDescription": "DEPRECATED. Use ``$schema``.",
@@ -1712,7 +1712,7 @@
       "type": "string"
     },
     "$schema": {
-      "default": "https://schemas.conda.org/menuinst-1-1-4.schema.json",
+      "default": "https://schemas.conda.org/menuinst-1-2-0.schema.json",
       "description": "Version of the menuinst schema to validate against.",
       "markdownDescription": "Version of the menuinst schema to validate against.",
       "minLength": 1,

--- a/menuinst/data/menuinst-1-2-0.schema.json
+++ b/menuinst/data/menuinst-1-2-0.schema.json
@@ -564,20 +564,6 @@
           "description": "Map of custom MIME types to their corresponding glob patterns (e.g. `*.txt`). Only needed if you define custom MIME types in `MimeType`.",
           "markdownDescription": "Map of custom MIME types to their corresponding glob patterns (e.g. `*.txt`). Only needed if you define custom MIME types in `MimeType`.",
           "title": "Glob Patterns"
-        },
-        "run_in_bash": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": true,
-          "description": "Whether to wrap `command` in a `bash -c` invocation.",
-          "markdownDescription": "Whether to wrap `command` in a `bash -c` invocation.",
-          "title": "Run In Bash"
         }
       },
       "title": "Linux",

--- a/menuinst/platforms/base.py
+++ b/menuinst/platforms/base.py
@@ -24,7 +24,7 @@ from ..utils import (
 )
 
 log = getLogger(__name__)
-SCHEMA_VERSION = "1-1-3"
+SCHEMA_VERSION = "1-1-4"
 
 
 class Menu:

--- a/menuinst/platforms/base.py
+++ b/menuinst/platforms/base.py
@@ -24,7 +24,7 @@ from ..utils import (
 )
 
 log = getLogger(__name__)
-SCHEMA_VERSION = "1-1-4"
+SCHEMA_VERSION = "1-2-0"
 
 
 class Menu:

--- a/menuinst/platforms/base.py
+++ b/menuinst/platforms/base.py
@@ -25,6 +25,12 @@ from ..utils import (
 
 log = getLogger(__name__)
 SCHEMA_VERSION = "1-2-0"
+#: Keys of the mappings accepted by the schema fields whose value depends on
+#: whether the target environment is the base environment or not. See
+#: `menuinst._schema.TargetIsBaseConStr` and `menuinst._schema.TargetIsBaseConList`.
+TARGET_ENVIRONMENT_KEYS = frozenset(
+    ("target_environment_is_base", "target_environment_is_not_base")
+)
 
 
 class Menu:
@@ -160,14 +166,32 @@ class MenuItem:
         self.menu = menu
         self._data = self._initialize_on_defaults(metadata)
         self.metadata = self._flatten_for_platform(self._data)
-        if isinstance(self.metadata["name"], dict):
-            if self.menu.prefix.samefile(self.menu.base_prefix):
-                name = self.metadata["name"].get("target_environment_is_base", "")
+        self._resolve_target_environment_keys(self.metadata)
+
+    def _resolve_target_environment_keys(self, metadata: dict[str, Any]) -> None:
+        """
+        Replace, in place, the values given as a `target_environment_is(_not)_base`
+        mapping with the branch that applies to this installation.
+
+        Fields opt into this by accepting `TargetIsBaseConStr`/`TargetIsBaseConList`
+        in the schema; here we only look at the shape of the value, so a field that
+        opts in later needs no change on this side.
+        """
+        is_base = None
+        for key, value in metadata.items():
+            if not isinstance(value, dict) or not value:
+                continue
+            if not TARGET_ENVIRONMENT_KEYS.issuperset(value):
+                continue
+            if is_base is None:
+                is_base = self.menu.prefix.samefile(self.menu.base_prefix)
+            if is_base:
+                resolved = value.get("target_environment_is_base")
             else:
-                name = self.metadata["name"].get("target_environment_is_not_base", "")
-            if not name:
-                raise ValueError("Cannot parse `name` from dictionary representation.")
-            self.metadata["name"] = name
+                resolved = value.get("target_environment_is_not_base")
+            if not resolved:
+                raise ValueError(f"Cannot parse `{key}` from dictionary representation.")
+            metadata[key] = resolved
 
     @property
     def location(self) -> Path:

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -237,6 +237,11 @@ class LinuxMenuItem(MenuItem):
     def _command(self) -> str:
         parts = []
         precommand = self.render_key("precommand")
+        if isinstance(precommand, dict):
+            if self.menu.prefix.samefile(self.menu.base_prefix):
+                precommand = precommand.get("target_environment_is_base", "")
+            else:
+                precommand = precommand.get("target_environment_is_not_base", "")
         if precommand:
             parts.append(precommand)
         if self.metadata["activate"]:
@@ -246,8 +251,22 @@ class LinuxMenuItem(MenuItem):
             else:
                 activate = "shell.bash activate"
             parts.append(f'eval "$("{conda_exe}" {activate} "{self.menu.prefix}")"')
-        parts.append(" ".join(UnixLex.quote_args(self.render_key("command"))))
-        return "bash -c " + shlex.quote(" && ".join(parts))
+        command = self.render_key("command")
+        if isinstance(command, dict):
+            if self.menu.prefix.samefile(self.menu.base_prefix):
+                command = command.get("target_environment_is_base", "")
+            else:
+                command = command.get("target_environment_is_not_base", "")
+        parts.append(" ".join(UnixLex.quote_args(command)))
+        # `run_in_bash` is a linux-only key, so it is absent whenever the menu item
+        # carries no `platforms.linux` block at all.
+        run_in_bash = self.metadata.get("run_in_bash")
+        if run_in_bash is None:
+            run_in_bash = True
+        if run_in_bash:
+            return "bash -c " + shlex.quote(" && ".join(parts))
+        else:
+            return " && ".join(parts)
 
     def _write_desktop_file(self):
         if self.location.exists():
@@ -281,6 +300,15 @@ class LinuxMenuItem(MenuItem):
             value = self.render_key(key)
             if value is None:
                 continue
+            if isinstance(value, dict):
+                if self.menu.prefix.samefile(self.menu.base_prefix):
+                    value = value.get("target_environment_is_base", "")
+                else:
+                    value = value.get("target_environment_is_not_base", "")
+                if not value:
+                    raise ValueError(f"Cannot parse `{key}` from dictionary representation.")
+
+            # Now parse as bool/list/str
             if isinstance(value, bool):
                 value = str(value).lower()
             elif isinstance(value, (list, tuple)):

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -258,7 +258,7 @@ class LinuxMenuItem(MenuItem):
             else:
                 command = command.get("target_environment_is_not_base", "")
         parts.append(" ".join(UnixLex.quote_args(command)))
-        return " && ".join(parts)
+        return "bash -c " + shlex.quote(" && ".join(parts))
 
     def _write_desktop_file(self):
         if self.location.exists():

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -237,11 +237,6 @@ class LinuxMenuItem(MenuItem):
     def _command(self) -> str:
         parts = []
         precommand = self.render_key("precommand")
-        if isinstance(precommand, dict):
-            if self.menu.prefix.samefile(self.menu.base_prefix):
-                precommand = precommand.get("target_environment_is_base", "")
-            else:
-                precommand = precommand.get("target_environment_is_not_base", "")
         if precommand:
             parts.append(precommand)
         if self.metadata["activate"]:
@@ -251,13 +246,7 @@ class LinuxMenuItem(MenuItem):
             else:
                 activate = "shell.bash activate"
             parts.append(f'eval "$("{conda_exe}" {activate} "{self.menu.prefix}")"')
-        command = self.render_key("command")
-        if isinstance(command, dict):
-            if self.menu.prefix.samefile(self.menu.base_prefix):
-                command = command.get("target_environment_is_base", "")
-            else:
-                command = command.get("target_environment_is_not_base", "")
-        parts.append(" ".join(UnixLex.quote_args(command)))
+        parts.append(" ".join(UnixLex.quote_args(self.render_key("command"))))
         return "bash -c " + shlex.quote(" && ".join(parts))
 
     def _write_desktop_file(self):
@@ -292,15 +281,6 @@ class LinuxMenuItem(MenuItem):
             value = self.render_key(key)
             if value is None:
                 continue
-            if isinstance(value, dict):
-                if self.menu.prefix.samefile(self.menu.base_prefix):
-                    value = value.get("target_environment_is_base", "")
-                else:
-                    value = value.get("target_environment_is_not_base", "")
-                if not value:
-                    raise ValueError(f"Cannot parse `{key}` from dictionary representation.")
-
-            # Now parse as bool/list/str
             if isinstance(value, bool):
                 value = str(value).lower()
             elif isinstance(value, (list, tuple)):

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -258,15 +258,7 @@ class LinuxMenuItem(MenuItem):
             else:
                 command = command.get("target_environment_is_not_base", "")
         parts.append(" ".join(UnixLex.quote_args(command)))
-        # `run_in_bash` is a linux-only key, so it is absent whenever the menu item
-        # carries no `platforms.linux` block at all.
-        run_in_bash = self.metadata.get("run_in_bash")
-        if run_in_bash is None:
-            run_in_bash = True
-        if run_in_bash:
-            return "bash -c " + shlex.quote(" && ".join(parts))
-        else:
-            return " && ".join(parts)
+        return " && ".join(parts)
 
     def _write_desktop_file(self):
         if self.location.exists():

--- a/news/334-target-environment-dicts
+++ b/news/334-target-environment-dicts
@@ -1,0 +1,22 @@
+### Enhancements
+
+* Allow `command`, `precommand`, and the Linux-only `StartupWMClass` and `TryExec`
+  fields to be given as a `{"target_environment_is_base": ..., "target_environment_is_not_base": ...}`
+  dictionary, the same form `name` already accepted. This bumps the schema version
+  to `1-2-0`. (#334)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* Document which fields can vary between base and non-base environments, and how. (#334)
+
+### Other
+
+* <news item>

--- a/tests/data/jsons/target-environment.json
+++ b/tests/data/jsons/target-environment.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://raw.githubusercontent.com/conda/menuinst/refs/heads/main/menuinst/data/menuinst.schema.json",
+  "menu_name": "Target environment",
+  "menu_items": [
+    {
+      "name": {
+        "target_environment_is_base": "Target environment is base",
+        "target_environment_is_not_base": "Target environment is {{ ENV_NAME }}"
+      },
+      "description": "Every base-or-not field at once, so the branches can be told apart.",
+      "icon": null,
+      "activate": false,
+      "precommand": {
+        "target_environment_is_base": "export TEST_VAR=base",
+        "target_environment_is_not_base": "export TEST_VAR=not-base"
+      },
+      "command": {
+        "target_environment_is_base": [
+          "echo",
+          "in base"
+        ],
+        "target_environment_is_not_base": [
+          "echo",
+          "not in base"
+        ]
+      },
+      "platforms": {
+        "win": {
+          "precommand": {
+            "target_environment_is_base": "set \"TEST_VAR=base\"",
+            "target_environment_is_not_base": "set \"TEST_VAR=not-base\""
+          }
+        },
+        "linux": {
+          "StartupWMClass": {
+            "target_environment_is_base": "base-wm-class",
+            "target_environment_is_not_base": "not-base-wm-class"
+          },
+          "TryExec": {
+            "target_environment_is_base": "{{ BASE_PYTHON }}",
+            "target_environment_is_not_base": "{{ PYTHON }}"
+          }
+        },
+        "osx": {}
+      }
+    }
+  ]
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -529,6 +529,103 @@ def test_name_dictionary(target_env_is_base):
         remove(abs_json_path, target_prefix=tmp_target_path, base_prefix=tmp_base_path)
 
 
+def _target_environment_prefixes(tmp_path, target_env_is_base):
+    base_prefix = tmp_path / "base"
+    base_prefix.mkdir(exist_ok=True)
+    if target_env_is_base:
+        return base_prefix, base_prefix
+    target_prefix = tmp_path / "someenv"
+    target_prefix.mkdir(exist_ok=True)
+    return base_prefix, target_prefix
+
+
+def _target_environment_item():
+    metadata = json.loads((DATA / "jsons" / "target-environment.json").read_text())
+    return metadata["menu_items"][0]
+
+
+@pytest.mark.parametrize("target_env_is_base", (True, False))
+def test_target_environment_dictionary(tmp_path, target_env_is_base):
+    """`name`, `precommand` and `command` each pick the branch that applies."""
+    base_prefix, target_prefix = _target_environment_prefixes(tmp_path, target_env_is_base)
+    menu = Menu("Target environment", prefix=str(target_prefix), base_prefix=str(base_prefix))
+    item = MenuItem(menu, _target_environment_item())
+
+    if target_env_is_base:
+        assert item.render_key("name") == "Target environment is base"
+        assert item.render_key("command") == ["echo", "in base"]
+    else:
+        assert item.render_key("name") == "Target environment is someenv"
+        assert item.render_key("command") == ["echo", "not in base"]
+
+    if PLATFORM == "win":
+        # The `platforms.win` block overrides the top-level `precommand`, and is
+        # itself a base-or-not dictionary.
+        expected = 'set "TEST_VAR=base"' if target_env_is_base else 'set "TEST_VAR=not-base"'
+    else:
+        expected = "export TEST_VAR=base" if target_env_is_base else "export TEST_VAR=not-base"
+    assert item.render_key("precommand") == expected
+
+
+@pytest.mark.skipif(PLATFORM != "linux", reason="Only relevant to .desktop files")
+@pytest.mark.parametrize("target_env_is_base", (True, False))
+def test_target_environment_desktop_entry(tmp_path, monkeypatch, target_env_is_base):
+    """Linux-only keys resolve too, and are rendered after the branch is picked."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    base_prefix, target_prefix = _target_environment_prefixes(tmp_path, target_env_is_base)
+    menu = LinuxMenu("Target environment", prefix=str(target_prefix), base_prefix=str(base_prefix))
+    menu._ensure_directories_exist()
+    item = LinuxMenuItem(menu, _target_environment_item())
+    item._write_desktop_file()
+    entry = item.location.read_text().splitlines()
+
+    if target_env_is_base:
+        assert "StartupWMClass=base-wm-class" in entry
+        assert f"TryExec={base_prefix / 'bin' / 'python'}" in entry
+        assert "Name=Target environment is base" in entry
+    else:
+        assert "StartupWMClass=not-base-wm-class" in entry
+        assert f"TryExec={target_prefix / 'bin' / 'python'}" in entry
+        assert "Name=Target environment is someenv" in entry
+
+    (exec_line,) = [line for line in entry if line.startswith("Exec=")]
+    if target_env_is_base:
+        assert "TEST_VAR=base" in exec_line
+        assert "in base" in exec_line and "not in base" not in exec_line
+    else:
+        assert "TEST_VAR=not-base" in exec_line
+        assert "not in base" in exec_line
+
+
+def test_target_environment_missing_branch(tmp_path):
+    """The branch that ends up applying must be present."""
+    base_prefix, target_prefix = _target_environment_prefixes(tmp_path, False)
+    menu = Menu("Target environment", prefix=str(target_prefix), base_prefix=str(base_prefix))
+    metadata = _target_environment_item()
+    metadata["command"] = {"target_environment_is_base": ["echo", "in base"]}
+    with pytest.raises(ValueError, match="Cannot parse `command`"):
+        MenuItem(menu, metadata)
+
+
+def test_target_environment_leaves_other_dicts_alone(tmp_path):
+    """Only mappings shaped like a base-or-not branch are collapsed."""
+    base_prefix, target_prefix = _target_environment_prefixes(tmp_path, False)
+    menu = Menu("Target environment", prefix=str(target_prefix), base_prefix=str(base_prefix))
+    item = MenuItem(menu, {"name": "Item", "command": ["echo", "hi"], "platforms": {}})
+    metadata = {
+        "glob_patterns": {"text/x-menuinst": "*.menuinst"},
+        "empty": {},
+        "partial": {"target_environment_is_base": "a", "unrelated": "b"},
+    }
+    item._resolve_target_environment_keys(metadata)
+    assert metadata == {
+        "glob_patterns": {"text/x-menuinst": "*.menuinst"},
+        "empty": {},
+        "partial": {"target_environment_is_base": "a", "unrelated": "b"},
+    }
+
+
 def test_vars_in_working_dir(tmp_path, monkeypatch, delete_files):
     if PLATFORM == "win":
         expected_directory = Path(os.environ["TEMP"], "working_dir_test")


### PR DESCRIPTION
In my workflow, I change a bit more than just the name depending on the environment being base or not. 
This expands the functionality of https://github.com/conda/menuinst/pull/180
xref: https://github.com/conda/menuinst/issues/207

This provides those switches.

It also provides a way to "not run inside a bash shell"

Let me know if you are interested in this, I need to go through the checklist.


### Checklist - did you ...

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/menuinst/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/menuinst/blob/main/CONTRIBUTING.md -->
