### PR TITLE
Decorator elevate_as_needed now respects .nonadmin

### DIFF
--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -271,7 +271,7 @@ class WindowsMenuItem(MenuItem):
             lines.append(precommand)
         if self.metadata["activate"]:
             if self.menu._is_micromamba(self.menu.conda_exe):
-                activator = f'{self.menu.conda_exe} shell activate "{self.menu.prefix}"'
+                activator = f'"{self.menu.conda_exe}" shell activate "{self.menu.prefix}"'
                 activation_lines = [
                     f'@FOR /F "usebackq tokens=*" %%i IN (`{activator}`) do set "ACTIVATOR=%%i"',
                     "@CALL %ACTIVATOR%",
@@ -293,7 +293,7 @@ class WindowsMenuItem(MenuItem):
                 filetype = activation_file.suffix
                 if filetype == ".bat":
                     activator = (
-                        f'{self.menu.conda_exe} shell.cmd.exe activate "{self.menu.prefix}"'
+                        f'"{self.menu.conda_exe}" shell.cmd.exe activate "{self.menu.prefix}"'
                     )
                     activation_lines = [
                         f'@FOR /F "usebackq tokens=*" %%i IN (`{activator}`) do set "ACTIVATOR=%%i"',  # noqa
@@ -304,7 +304,7 @@ class WindowsMenuItem(MenuItem):
                     for line in activation_file.read_text().splitlines():
                         keyword, value = line.strip().split("=", 1)
                         if keyword == "_CONDA_SCRIPT":
-                            activation_lines.append(f"@CALL {value}")
+                            activation_lines.append(f'@CALL "{value}"')
                         else:
                             activation_lines.append(f'@SET "{keyword}={value}"')
                 else:

--- a/menuinst/utils.py
+++ b/menuinst/utils.py
@@ -507,11 +507,16 @@ def elevate_as_needed(func: Callable) -> Callable:
                 if return_code == 0:  # success, we are done
                     return
         elif user_is_admin():
-            # We are already running as admin, no need to elevate
+            # We are already running as admin, but check if .nonadmin marker exists
+            # which signals a user-mode install (e.g., per-user MSI install running elevated)
+            nonadmin_exists = (
+                Path(target_prefix, ".nonadmin").is_file()
+                or Path(base_prefix, ".nonadmin").is_file()
+            )
             return func(
                 target_prefix=target_prefix,
                 base_prefix=base_prefix,
-                _mode="system",
+                _mode="user" if nonadmin_exists else "system",
                 *args,
                 **kwargs,
             )

--- a/menuinst/utils.py
+++ b/menuinst/utils.py
@@ -508,7 +508,7 @@ def elevate_as_needed(func: Callable) -> Callable:
                     return
         elif user_is_admin():
             # We are already running as admin, but check if .nonadmin marker exists
-            # which signals a user-mode install (e.g., per-user MSI install running elevated)
+            # which signals a user-mode install.
             nonadmin_exists = (
                 Path(target_prefix, ".nonadmin").is_file()
                 or Path(base_prefix, ".nonadmin").is_file()

--- a/menuinst/utils.py
+++ b/menuinst/utils.py
@@ -507,8 +507,7 @@ def elevate_as_needed(func: Callable) -> Callable:
                 if return_code == 0:  # success, we are done
                     return
         elif user_is_admin():
-            # We are already running as admin, but check if .nonadmin marker exists
-            # which signals a user-mode install.
+            # On Windows, check if .nonadmin marker exists which signals a user-mode install.
             nonadmin_exists = (
                 Path(target_prefix, ".nonadmin").is_file()
                 or Path(base_prefix, ".nonadmin").is_file()
@@ -516,7 +515,7 @@ def elevate_as_needed(func: Callable) -> Callable:
             return func(
                 target_prefix=target_prefix,
                 base_prefix=base_prefix,
-                _mode="user" if nonadmin_exists else "system",
+                _mode="user" if nonadmin_exists and os.name == "nt" else "system",
                 *args,
                 **kwargs,
             )

--- a/news/454-fix-nonadmin-when-admin
+++ b/news/454-fix-nonadmin-when-admin
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* On Windows, the `@elevate_as_needed` decorator now respects the `.nonadmin` marker file when running as admin, using user mode instead of system mode. (#453 via #454)
+* The `@elevate_as_needed` decorator now respects the `.nonadmin` marker file when running as admin/root, using user mode instead of system mode. (#453 via #454)
 
 ### Deprecations
 

--- a/news/454-fix-nonadmin-when-admin
+++ b/news/454-fix-nonadmin-when-admin
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* On Windows, the `@elevate_as_needed` decorator now respects the `.nonadmin` marker file when running as admin, using user mode instead of system mode. (#453 via #454)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/454-fix-nonadmin-when-admin
+++ b/news/454-fix-nonadmin-when-admin
@@ -4,7 +4,8 @@
 
 ### Bug fixes
 
-* The `@elevate_as_needed` decorator now respects the `.nonadmin` marker file when running as admin/root, using user mode instead of system mode. (#453 via #454)
+* On Windows, the `@elevate_as_needed` decorator now respects the `.nonadmin` marker file when running as admin, using user mode instead of system mode. (#453 via #454)
+* On Windows, fixed path quoting in activation scripts for installations with spaces in the path. (#454)
 
 ### Deprecations
 

--- a/tests/test_elevation.py
+++ b/tests/test_elevation.py
@@ -50,17 +50,18 @@ def test_elevation(tmp_path, capfd):
 
 
 @pytest.mark.parametrize(
-    "create_nonadmin,expected_mode",
+    "create_nonadmin,expected_mode_win",
     [
         (True, "user"),
         (False, "system"),
     ],
 )
 def test_elevation_nonadmin_marker_when_admin(
-    tmp_path, monkeypatch, create_nonadmin, expected_mode
+    tmp_path, monkeypatch, capfd, create_nonadmin, expected_mode_win
 ):
     """
-    Test that .nonadmin marker is respected when running as admin.
+    Test that .nonadmin marker is respected when running as admin on Windows.
+    On non-Windows, admin always uses system mode.
     See https://github.com/conda/menuinst/issues/453
     """
     os.environ["MENUINST_TEST"] = "TEST"
@@ -74,4 +75,8 @@ def test_elevation_nonadmin_marker_when_admin(
 
     if os.name == "nt":
         output = (tmp_path / "_test_output.txt").read_text().strip()
-        assert f"_mode: {expected_mode}" in output
+        assert f"_mode: {expected_mode_win}" in output
+    else:
+        # On non-Windows, admin always uses system mode regardless of .nonadmin
+        output = capfd.readouterr().out.strip()
+        assert "_mode: system" in output

--- a/tests/test_elevation.py
+++ b/tests/test_elevation.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from menuinst.utils import _test_elevation, elevate_as_needed, user_is_admin
 
 
@@ -44,3 +46,31 @@ def test_elevation(tmp_path, capfd):
         elevate_as_needed(_test_elevation)(target_prefix=str(tmp_path), base_prefix=str(tmp_path))
         assert capfd.readouterr().out.strip() == "user_is_admin(): False env_var: TEST _mode: user"
         assert (tmp_path / ".nonadmin").exists()
+
+
+@pytest.mark.parametrize(
+    "create_nonadmin,expected_mode",
+    [
+        (True, "user"),
+        (False, "system"),
+    ],
+)
+def test_elevation_nonadmin_marker_when_admin(
+    tmp_path, monkeypatch, create_nonadmin, expected_mode
+):
+    """
+    Test that .nonadmin marker is respected when running as admin.
+    See https://github.com/conda/menuinst/issues/453
+    """
+    os.environ["MENUINST_TEST"] = "TEST"
+
+    if create_nonadmin:
+        (tmp_path / ".nonadmin").touch()
+
+    monkeypatch.setattr("menuinst.utils.user_is_admin", lambda: True)
+
+    elevate_as_needed(_test_elevation)(target_prefix=str(tmp_path), base_prefix=str(tmp_path))
+
+    if os.name == "nt":
+        output = (tmp_path / "_test_output.txt").read_text().strip()
+        assert f"_mode: {expected_mode}" in output

--- a/tests/test_elevation.py
+++ b/tests/test_elevation.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from menuinst import utils as menuinst_utils
 from menuinst.utils import _test_elevation, elevate_as_needed, user_is_admin
 
 
@@ -67,7 +68,7 @@ def test_elevation_nonadmin_marker_when_admin(
     if create_nonadmin:
         (tmp_path / ".nonadmin").touch()
 
-    monkeypatch.setattr("menuinst.utils.user_is_admin", lambda: True)
+    monkeypatch.setattr(menuinst_utils, "user_is_admin", lambda: True)
 
     elevate_as_needed(_test_elevation)(target_prefix=str(tmp_path), base_prefix=str(tmp_path))
 

--- a/tests/test_windows_menu_item.py
+++ b/tests/test_windows_menu_item.py
@@ -137,7 +137,9 @@ def test_command_quotes_paths_with_spaces(conda_exe_path, prefix_path, monkeypat
 
     # Create a fake .env file
     fake_env_file = tmp_path / "activate.env"
-    fake_env_content = f"_CONDA_SCRIPT={prefix_path}\\Scripts\\activate.bat\nCONDA_PREFIX={prefix_path}"
+    fake_env_content = (
+        f"_CONDA_SCRIPT={prefix_path}\\Scripts\\activate.bat\nCONDA_PREFIX={prefix_path}"
+    )
     fake_env_file.write_text(fake_env_content)
 
     # Create a menu item with activate=True to trigger the activation code path
@@ -184,14 +186,14 @@ def test_command_quotes_paths_with_spaces(conda_exe_path, prefix_path, monkeypat
     lines = command.split("\r\n")
 
     # Find the @CALL line for _CONDA_SCRIPT
-    call_lines = [l for l in lines if l.startswith("@CALL")]
+    call_lines = [line for line in lines if line.startswith("@CALL")]
     assert len(call_lines) >= 1, f"Expected @CALL line in command, got: {lines}"
 
     # The path in @CALL should be quoted if it contains spaces
     if " " in prefix_path:
         call_line = call_lines[0]
         # The path should be wrapped in quotes
-        assert f'"{prefix_path}' in call_line or f'@CALL "' in call_line, (
+        assert f'"{prefix_path}' in call_line or '@CALL "' in call_line, (
             f"Path with spaces should be quoted in @CALL. Got: {call_line}"
         )
 

--- a/tests/test_windows_menu_item.py
+++ b/tests/test_windows_menu_item.py
@@ -118,6 +118,85 @@ def test_process_command_as_activated_and_terminal(with_arg1):
 
 
 @pytest.mark.skipif(PLATFORM != "win", reason="Windows only")
+@pytest.mark.parametrize(
+    "conda_exe_path,prefix_path",
+    [
+        (r"C:\Program Files\FooBar\conda.exe", r"C:\Program Files\FooBar"),
+        (r"C:\FooBar 123\base\_conda.exe", r"C:\FooBar 123\base"),
+        (r"C:\path with spaces\conda.exe", r"C:\path with spaces\envs\test"),
+    ],
+)
+def test_command_quotes_paths_with_spaces(conda_exe_path, prefix_path, monkeypatch, tmp_path):
+    """Test that _command() properly quotes conda_exe and prefix paths containing spaces.
+
+    Regression test for installation paths that contain spaces.
+    Without proper quoting, batch files would fail with:
+    'C:\\path\\FooBar' is not recognized as an internal or external command
+    """
+    from menuinst.platforms import win as win_module
+
+    # Create a fake .env file
+    fake_env_file = tmp_path / "activate.env"
+    fake_env_content = f"_CONDA_SCRIPT={prefix_path}\\Scripts\\activate.bat\nCONDA_PREFIX={prefix_path}"
+    fake_env_file.write_text(fake_env_content)
+
+    # Create a menu item with activate=True to trigger the activation code path
+    class TestMenu(WindowsMenu):
+        def __init__(self):
+            self.mode = "user"
+            self.name = "Test"
+            self.prefix = Path(prefix_path)
+            self.base_prefix = Path(prefix_path).parent
+            self.env_name = "test"
+            self._conda_exe = Path(conda_exe_path)
+
+        @property
+        def conda_exe(self):
+            return self._conda_exe
+
+        def _is_micromamba(self, exe):
+            return False
+
+        def render(self, value, slug=False, extra=None):
+            return value
+
+    menu = TestMenu()
+    metadata = {
+        "activate": True,
+        "terminal": False,
+        "name": "Test App",
+        "command": ["python", "-c", "print('hello')"],
+        "precommand": None,
+    }
+
+    item = WindowsMenuItem(menu, metadata)
+
+    # Mock logged_run to return the fake .env file path
+    class FakeRunResult:
+        stdout = str(fake_env_file)
+
+    monkeypatch.setattr(win_module, "logged_run", lambda *args, **kwargs: FakeRunResult())
+
+    # Generate the command
+    command = item._command()
+
+    # Verify that paths with spaces are quoted in the generated batch script
+    lines = command.split("\r\n")
+
+    # Find the @CALL line for _CONDA_SCRIPT
+    call_lines = [l for l in lines if l.startswith("@CALL")]
+    assert len(call_lines) >= 1, f"Expected @CALL line in command, got: {lines}"
+
+    # The path in @CALL should be quoted if it contains spaces
+    if " " in prefix_path:
+        call_line = call_lines[0]
+        # The path should be wrapped in quotes
+        assert f'"{prefix_path}' in call_line or f'@CALL "' in call_line, (
+            f"Path with spaces should be quoted in @CALL. Got: {call_line}"
+        )
+
+
+@pytest.mark.skipif(PLATFORM != "win", reason="Windows only")
 def test_run_generated_command(tmp_path):
     """This test does several thing to mimic in-production use of WindowsMenuItems.
     * Create a command, containing spaces, metachars and environment variables.


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR resolves: https://github.com/conda/menuinst/issues/453.
The `@elevate_as_needed` decorator ignored the `.nonadmin` marker file when `user_is_admin()` returned `True`, always using system mode.
This caused shortcuts to be created in the system location (ProgramData) instead of the user location (AppData) for per-user installs running in an elevated context.

The fix checks for `.nonadmin` before defaulting to system mode when admin.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/menuinst/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/menuinst/blob/main/CONTRIBUTING.md -->
