### PR TITLE
Fix conditional platforms and logging

### DIFF
--- a/menuinst/api.py
+++ b/menuinst/api.py
@@ -74,7 +74,8 @@ def install(
     paths = []
     paths += menu.create()
     for menu_item in menu_items:
-        paths += menu_item.create()
+        if menu_item.enabled_for_platform():
+            paths += menu_item.create()
 
     return paths
 
@@ -96,7 +97,8 @@ def remove(
 
     paths = []
     for menu_item in menu_items:
-        paths += menu_item.remove()
+        if menu_item.enabled_for_platform():
+            paths += menu_item.remove()
     paths += menu.remove()
 
     if not paths and _maybe_try_user(target_prefix, base_prefix):

--- a/menuinst/api.py
+++ b/menuinst/api.py
@@ -67,15 +67,15 @@ def install(
     target_prefix = target_prefix or DEFAULT_PREFIX
     base_prefix = base_prefix or DEFAULT_BASE_PREFIX
     menu, menu_items = _load(metadata_or_path, target_prefix, base_prefix, _mode)
-    if not any(item.enabled_for_platform() for item in menu_items):
+    menu_items = [item for item in menu_items if item.enabled_for_platform()]
+    if not menu_items:
         warnings.warn(f"Metadata for {menu.name} is not enabled for {sys.platform}")
         return []
 
     paths = []
     paths += menu.create()
     for menu_item in menu_items:
-        if menu_item.enabled_for_platform():
-            paths += menu_item.create()
+        paths += menu_item.create()
 
     return paths
 
@@ -91,21 +91,21 @@ def remove(
     target_prefix = target_prefix or DEFAULT_PREFIX
     base_prefix = base_prefix or DEFAULT_BASE_PREFIX
     menu, menu_items = _load(metadata_or_path, target_prefix, base_prefix, _mode)
-    if not any(item.enabled_for_platform() for item in menu_items):
+    menu_items = [item for item in menu_items if item.enabled_for_platform()]
+    if not menu_items:
         warnings.warn(f"Metadata for {menu.name} is not enabled for {sys.platform}")
         return []
 
     paths = []
     for menu_item in menu_items:
-        if menu_item.enabled_for_platform():
-            paths += menu_item.remove()
+        paths += menu_item.remove()
     paths += menu.remove()
 
     if not paths and _maybe_try_user(target_prefix, base_prefix):
         menu, menu_items = _load(metadata_or_path, target_prefix, base_prefix, "user")
+        menu_items = [item for item in menu_items if item.enabled_for_platform()]
         for menu_item in menu_items:
-            if menu_item.enabled_for_platform():
-                paths += menu_item.remove()
+            paths += menu_item.remove()
         paths += menu.remove()
 
     return paths

--- a/menuinst/api.py
+++ b/menuinst/api.py
@@ -104,7 +104,8 @@ def remove(
     if not paths and _maybe_try_user(target_prefix, base_prefix):
         menu, menu_items = _load(metadata_or_path, target_prefix, base_prefix, "user")
         for menu_item in menu_items:
-            paths += menu_item.remove()
+            if menu_item.enabled_for_platform():
+                paths += menu_item.remove()
         paths += menu.remove()
 
     return paths

--- a/menuinst/platforms/base.py
+++ b/menuinst/platforms/base.py
@@ -169,6 +169,14 @@ class MenuItem:
             "MENU_ITEM_LOCATION": str(self.location),
         }
 
+    @property
+    def _log_name(self) -> str:
+        name = self.menu.name
+        item_name = self.render_key("name")
+        if item_name:
+            name = f"{name}->{item_name}"
+        return name
+
     def render_key(self, key: str, slug: bool = False, extra: dict[str, str] | None = None) -> Any:
         value = self.metadata.get(key)
         return self.render(value, slug=slug, extra=extra)

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -241,7 +241,7 @@ class LinuxMenuItem(MenuItem):
 
     def _write_desktop_file(self):
         if self.location.exists():
-            log.warning("Overwriting existing file at %s.", self.location)
+            log.warning("%s: Overwriting existing file at %s.", self._log_name, self.location)
 
         lines = [
             "[Desktop Entry]",
@@ -394,13 +394,12 @@ class LinuxMenuItem(MenuItem):
                         check=True,
                     )
                 else:
-                    name = self.render_key("name")
                     log.warning(
-                        "Unable to un/register MIME type '%s' "
-                        "for Desktop Entry of name '%s': "
+                        "%s: Unable to un/register MIME type '%s' "
+                        "for Desktop Entry: "
                         "'xdg-mime' is not present on the system.'",
+                        self._log_name,
                         glob_pattern,
-                        name,
                     )
                     use_fallback = True
         except CalledProcessError:

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -86,7 +86,7 @@ class WindowsMenu(Menu):
         not when it is installed.
         """
         if self.mode == "system":
-            log.warning("Terminal profiles are not available for system level installs")
+            log.warning("%s: Terminal profiles are not available for system level installs", self.name)
             return []
         return windows_terminal_settings_files(self.mode)
 
@@ -185,7 +185,7 @@ class WindowsMenuItem(MenuItem):
             # winshortcut.create_shortcut(path, description, filename, arguments="",
             #                             workdir=None, iconpath=None, iconindex=0, app_id="")
             if Path(path).exists():
-                log.warning("Overwriting existing link at %s.", path)
+                log.warning("%s: Overwriting existing link at %s.", self._log_name, path)
             create_shortcut(
                 target_path,
                 self._shortcut_filename(ext=""),
@@ -422,7 +422,7 @@ class WindowsMenuItem(MenuItem):
                     settings["profiles"]["list"] = []
                 settings["profiles"]["list"].append(profile_data)
             else:
-                log.warning(f"Overwriting terminal profile for {name}.")
+                log.warning(f"{self._log_name}: Overwriting terminal profile for {name}.")
                 settings["profiles"]["list"][index] = profile_data
         location.write_text(json.dumps(settings, indent=4))
 

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -424,7 +424,7 @@ class WindowsMenuItem(MenuItem):
                     settings["profiles"]["list"] = []
                 settings["profiles"]["list"].append(profile_data)
             else:
-                log.warning(f"{self._log_name}: Overwriting terminal profile for {name}.")
+                log.warning("%s: Overwriting terminal profile for %s.", self._log_name, name)
                 settings["profiles"]["list"][index] = profile_data
         location.write_text(json.dumps(settings, indent=4))
 

--- a/menuinst/platforms/win.py
+++ b/menuinst/platforms/win.py
@@ -86,7 +86,9 @@ class WindowsMenu(Menu):
         not when it is installed.
         """
         if self.mode == "system":
-            log.warning("%s: Terminal profiles are not available for system level installs", self.name)
+            log.warning(
+                "%s: Terminal profiles are not available for system level installs", self.name
+            )
             return []
         return windows_terminal_settings_files(self.mode)
 

--- a/news/475-platform-conditional
+++ b/news/475-platform-conditional
@@ -1,10 +1,10 @@
 ### Enhancements
 
-* Improved logging of warnings during installation (#475)
+* Improved logging of warnings during installation (#464 via #475)
 
 ### Bug fixes
 
-* Fix bug where menus containing some platform-specific shortcuts would lead to install and removal errors (#475)
+* Fix bug where menus containing some platform-specific shortcuts would lead to install and removal errors (#463 via #475)
 
 ### Deprecations
 

--- a/news/475-platform-conditional
+++ b/news/475-platform-conditional
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Improved logging of warnings during installation (#475)
+
+### Bug fixes
+
+* Fix bug where menus containing some platform-specific shortcuts would lead to install and removal errors (#475)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/data/jsons/conditional-platforms.json
+++ b/tests/data/jsons/conditional-platforms.json
@@ -4,11 +4,15 @@
   "menu_items": [
     {
       "name": "b-all-platforms",
-      "command": ["foo"],
+      "command": [
+        "foo"
+      ],
       "activate": false,
       "terminal": false,
       "platforms": {
-        "win": {"desktop": false},
+        "win": {
+          "desktop": false
+        },
         "linux": {},
         "osx": {}
       }
@@ -17,10 +21,14 @@
       "name": "c-linux-only",
       "activate": false,
       "terminal": false,
-      "command": [""],
+      "command": [
+        ""
+      ],
       "platforms": {
         "linux": {
-          "command": ["foo"]
+          "command": [
+            "foo"
+          ]
         }
       }
     }

--- a/tests/data/jsons/conditional-platforms.json
+++ b/tests/data/jsons/conditional-platforms.json
@@ -4,6 +4,7 @@
   "menu_items": [
     {
       "name": "b-all-platforms",
+      "description": "Shortcut on all platforms",
       "command": [
         "foo"
       ],
@@ -19,6 +20,7 @@
     },
     {
       "name": "c-linux-only",
+      "description": "Shortcut only on Linux",
       "activate": false,
       "terminal": false,
       "command": [

--- a/tests/data/jsons/conditional-platforms.json
+++ b/tests/data/jsons/conditional-platforms.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/conda/menuinst/refs/heads/main/menuinst/data/menuinst.schema.json",
+  "menu_name": "a-platform-test",
+  "menu_items": [
+    {
+      "name": "b-all-platforms",
+      "command": ["foo"],
+      "activate": false,
+      "terminal": false,
+      "platforms": {
+        "win": {"desktop": false},
+        "linux": {},
+        "osx": {}
+      }
+    },
+    {
+      "name": "c-linux-only",
+      "activate": false,
+      "terminal": false,
+      "command": [""],
+      "platforms": {
+        "linux": {
+          "command": ["foo"]
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -529,7 +529,8 @@ def test_platforms(tmp_path):
 
     # And now some more complete tests:
 
-    # No platforms
+
+def test_no_platforms(tmp_path, delete_files):
     datafile = str(DATA / "jsons" / "no-platforms.json")
     try:
         item_names = install(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
@@ -540,7 +541,8 @@ def test_platforms(tmp_path):
     finally:
         remove(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
 
-    # Conditional platforms
+
+def test_conditional_platforms(tmp_path, delete_files):
     datafile = str(DATA / "jsons" / "conditional-platforms.json")
     want_names = []
     if PLATFORM != "osx":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -212,7 +212,8 @@ def test_overwrite_existing_shortcuts(delete_files, caplog):
             "precommands.json",
             remove_after=True,
         )
-        assert any(line.startswith("Overwriting existing") for line in caplog.messages)
+        want_msg = "Example with precommands->Precommands: Overwriting existing"
+        assert any(line.startswith(want_msg) for line in caplog.messages)
 
 
 @pytest.mark.skipif(PLATFORM == "osx", reason="No menu names on MacOS")
@@ -513,7 +514,7 @@ def test_vars_in_working_dir(tmp_path, monkeypatch, delete_files):
         remove(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
 
 
-def test_platforms():
+def test_platforms(tmp_path):
     menu_item = MenuItem(
         None,
         {
@@ -525,6 +526,38 @@ def test_platforms():
     assert menu_item.enabled_for_platform("win32")
     assert not menu_item.enabled_for_platform("linux")
     assert not menu_item.enabled_for_platform("darwin")
+
+    # And now some more complete tests:
+
+    # No platforms
+    datafile = str(DATA / "jsons" / "no-platforms.json")
+    try:
+        item_names = install(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
+    except Exception:
+        raise
+    else:
+        assert item_names == []
+    finally:
+        remove(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
+
+    # Conditional platforms
+    datafile = str(DATA / "jsons" / "conditional-platforms.json")
+    want_names = []
+    if PLATFORM != "osx":
+        want_names.append("a-platform-test")
+    want_names.append("b-all-platforms")
+    if PLATFORM == "linux":
+        want_names.append("c-linux-only")
+        want_names = [want_names[0]]+ [f"{want_names[0]}_{name}" for name in want_names[1:]]
+    try:
+        item_names = install(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
+    except Exception:
+        raise
+    else:
+        item_names = sorted(item.stem for item in item_names)
+        assert item_names == want_names
+    finally:
+        remove(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
 
 
 def test_malformed_json_skipped_in_process_all(tmp_path, caplog):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -548,7 +548,7 @@ def test_platforms(tmp_path):
     want_names.append("b-all-platforms")
     if PLATFORM == "linux":
         want_names.append("c-linux-only")
-        want_names = [want_names[0]]+ [f"{want_names[0]}_{name}" for name in want_names[1:]]
+        want_names = [want_names[0]] + [f"{want_names[0]}_{name}" for name in want_names[1:]]
     try:
         item_names = install(datafile, base_prefix=tmp_path, target_prefix=tmp_path)
     except Exception:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -527,8 +527,6 @@ def test_platforms(tmp_path):
     assert not menu_item.enabled_for_platform("linux")
     assert not menu_item.enabled_for_platform("darwin")
 
-    # And now some more complete tests:
-
 
 def test_no_platforms(tmp_path, delete_files):
     datafile = str(DATA / "jsons" / "no-platforms.json")


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes #463
Closes #464

Turns out the issue was a gap in testing and logic: current tests were only "all plugins enabled for the same set of platforms" (which could be all platforms, or a subset of platforms). Once I added a test for "some plugins enabled for not all platforms, some enabled for all platforms" the problem became clear.

I also added logging of the menu and menuitem name in the warnings.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] ~~Add / update outdated documentation?~~

Related PR also opened for `conda` in https://github.com/conda/conda/pull/16000