### PR TITLE
Test fix for canary builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,18 @@ jobs:
   build:
     name: Canary Build
     needs: [run_test_suite]
+    # only build canary build if
+    # - prior steps succeeded,
+    # - this is the main repo, and
+    # - we are on the main, feature, or release branch
+    if: >-
+      always()
+      && !github.event.repository.fork
+      && (
+        github.ref_name == 'main'
+        || startsWith(github.ref_name, 'feature/')
+        || endsWith(github.ref_name, '.x')
+      )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,18 +102,6 @@ jobs:
   build:
     name: Canary Build
     needs: [run_test_suite]
-    # only build canary build if
-    # - prior steps succeeded,
-    # - this is the main repo, and
-    # - we are on the main, feature, or release branch
-    if: >-
-      always()
-      && !github.event.repository.fork
-      && (
-        github.ref_name == 'main'
-        || startsWith(github.ref_name, 'feature/')
-        || endsWith(github.ref_name, '.x')
-      )
     strategy:
       fail-fast: false
       matrix:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,12 @@ test:
     - menuinst
   commands:
     - menuinst --help
+    # Point menuinst at the test env's conda to avoid ABI mismatch when
+    # conda-build's tooling env uses a different Python version.
+    - export CONDA_EXE="${CONDA_PREFIX}/bin/conda"  # [unix]
+    - export CONDA_ROOT_PREFIX="${CONDA_PREFIX}"  # [unix]
+    - set "CONDA_EXE=%CONDA_PREFIX%\Scripts\conda.exe"  # [win]
+    - set "CONDA_ROOT_PREFIX=%CONDA_PREFIX%"  # [win]
     - unset CI  # [unix]
     - set "CI="  # [win]
     - pytest --no-cov -vv -k "not elevation"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This PR includes a fix for canary builds.
During `conda-build` `CONDA_EXE` may point at `conda` from a separate temporary environment used for building. This PR changes so we use the correct `conda` during testing.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/menuinst/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/menuinst/blob/main/CONTRIBUTING.md -->
