### PR TITLE
Make tests more robust and gracefully handle permission denied when creating `menuinst.toml` 

### DIFF
--- a/menuinst/api.py
+++ b/menuinst/api.py
@@ -62,7 +62,14 @@ def record_shortcuts(
     for path in paths:
         shortcuts.append({"source": source, "path": str(path)})
 
-    write_menuinst_toml(prefix, data)
+    try:
+        write_menuinst_toml(prefix, data)
+    except PermissionError:
+        log.debug(
+            "Cannot write menuinst.toml to %s (permission denied). "
+            "Shortcut tracking will not be available for this prefix.",
+            prefix / "Menu",
+        )
 
 
 def remove_shortcut_records(prefix: Path, source: str) -> None:
@@ -86,7 +93,13 @@ def remove_shortcut_records(prefix: Path, source: str) -> None:
         return  # Nothing was removed
 
     data["shortcuts"] = filtered
-    write_menuinst_toml(prefix, data)
+    try:
+        write_menuinst_toml(prefix, data)
+    except PermissionError:
+        log.debug(
+            "Cannot update menuinst.toml at %s (permission denied).",
+            prefix / "Menu",
+        )
 
 
 def _load(

--- a/news/497-improve-tests
+++ b/news/497-improve-tests
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Gracefully handle permission errors when writing `menuinst.toml` in read-only environments. (#496)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* Refactor some tests to use temporary directories instead of using `sys.prefix`. (#496)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,11 +77,18 @@ def check_output_from_shortcut(
         # We symlink to sys.executable; copying doesn't work (can't find runtime libraries).
         if PLATFORM == "win":
             python_path = Path(tmp_base_path) / "python.exe"
+            try:
+                python_path.symlink_to(sys.executable)
+            except OSError:
+                # If symlinks are not available;
+                # fall back to sys.prefix; tests lose isolation but still run.
+                delete_files.remove(tmp_base_path)
+                tmp_base_path = sys.prefix
         else:
             bin_dir = Path(tmp_base_path) / "bin"
             bin_dir.mkdir(exist_ok=True)
             python_path = bin_dir / "python"
-        python_path.symlink_to(sys.executable)
+            python_path.symlink_to(sys.executable)
 
     paths = install(abs_json_path, target_prefix=tmp_base_path, base_prefix=tmp_base_path)
     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,7 +63,7 @@ def check_output_from_shortcut(
     tmp_base_path = mkdtemp()
     delete_files.append(tmp_base_path)
     (Path(tmp_base_path) / ".nonadmin").touch()
-    paths = install(abs_json_path, base_prefix=tmp_base_path)
+    paths = install(abs_json_path, target_prefix=sys.prefix, base_prefix=tmp_base_path)
     try:
         if action == "run_shortcut":
             if PLATFORM == "win":
@@ -114,7 +114,7 @@ def check_output_from_shortcut(
         if paths:
             delete_files += list(paths)
         if remove_after:
-            remove(abs_json_path, base_prefix=tmp_base_path)
+            remove(abs_json_path, target_prefix=sys.prefix, base_prefix=tmp_base_path)
         if PLATFORM == "osx" and action in ("open_file", "open_url"):
             _lsregister(
                 "-kill",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,7 +73,8 @@ def check_output_from_shortcut(
         (Path(tmp_base_path) / ".nonadmin").touch()
         # conda-meta makes conda treat this as a valid environment for activation
         (Path(tmp_base_path) / "conda-meta").mkdir(exist_ok=True)
-        # Symlink to real Python so {{ PYTHON }} placeholder works
+        # Shortcuts use {{ PYTHON }} which resolves to prefix/python.exe or prefix/bin/python.
+        # We symlink to sys.executable; copying doesn't work (can't find runtime libraries).
         if PLATFORM == "win":
             python_path = Path(tmp_base_path) / "python.exe"
         else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,10 +60,29 @@ def check_output_from_shortcut(
         abs_json_path = tmp.name
         delete_files.append(abs_json_path)
 
-    tmp_base_path = mkdtemp()
-    delete_files.append(tmp_base_path)
-    (Path(tmp_base_path) / ".nonadmin").touch()
-    paths = install(abs_json_path, target_prefix=sys.prefix, base_prefix=tmp_base_path)
+    # Windows file/URL association tests need sys.prefix because symlinked Python
+    # doesn't work through the file association handler (registry lookup -> cmd -> batch).
+    # These tests only run on CI where sys.prefix is a writable conda environment.
+    use_real_prefix = PLATFORM == "win" and action in ("open_file", "open_url")
+
+    if use_real_prefix:
+        tmp_base_path = sys.prefix
+    else:
+        tmp_base_path = mkdtemp()
+        delete_files.append(tmp_base_path)
+        (Path(tmp_base_path) / ".nonadmin").touch()
+        # conda-meta makes conda treat this as a valid environment for activation
+        (Path(tmp_base_path) / "conda-meta").mkdir(exist_ok=True)
+        # Symlink to real Python so {{ PYTHON }} placeholder works
+        if PLATFORM == "win":
+            python_path = Path(tmp_base_path) / "python.exe"
+        else:
+            bin_dir = Path(tmp_base_path) / "bin"
+            bin_dir.mkdir(exist_ok=True)
+            python_path = bin_dir / "python"
+        python_path.symlink_to(sys.executable)
+
+    paths = install(abs_json_path, target_prefix=tmp_base_path, base_prefix=tmp_base_path)
     try:
         if action == "run_shortcut":
             if PLATFORM == "win":
@@ -114,7 +133,7 @@ def check_output_from_shortcut(
         if paths:
             delete_files += list(paths)
         if remove_after:
-            remove(abs_json_path, target_prefix=sys.prefix, base_prefix=tmp_base_path)
+            remove(abs_json_path, target_prefix=tmp_base_path, base_prefix=tmp_base_path)
         if PLATFORM == "osx" and action in ("open_file", "open_url"):
             _lsregister(
                 "-kill",
@@ -273,7 +292,7 @@ def test_precommands(delete_files):
 
 @pytest.mark.skipif(PLATFORM != "osx", reason="macOS only")
 def test_entitlements(delete_files):
-    json_path, paths, *_ = check_output_from_shortcut(
+    json_path, paths, tmp_base_path, _ = check_output_from_shortcut(
         delete_files, "entitlements.json", remove_after=False, expected_output="entitlements"
     )
     # verify signature
@@ -300,12 +319,12 @@ def test_entitlements(delete_files):
     else:
         raise AssertionError("Didn't find Entitlements.plist")
 
-    remove(json_path)
+    remove(json_path, target_prefix=tmp_base_path, base_prefix=tmp_base_path)
 
 
 @pytest.mark.skipif(PLATFORM != "osx", reason="macOS only")
 def test_no_entitlements_no_signature(delete_files):
-    json_path, paths, *_ = check_output_from_shortcut(
+    json_path, paths, tmp_base_path, _ = check_output_from_shortcut(
         delete_files, "sys-prefix.json", remove_after=False, expected_output=sys.prefix
     )
     app_dir = next(p for p in paths if p.name.endswith(".app"))
@@ -316,12 +335,12 @@ def test_no_entitlements_no_signature(delete_files):
         subprocess.check_call(["/usr/bin/codesign", "--verbose", "--verify", str(app_dir)])
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call(["/usr/bin/codesign", "--verbose", "--verify", str(launcher)])
-    remove(json_path)
+    remove(json_path, target_prefix=tmp_base_path, base_prefix=tmp_base_path)
 
 
 @pytest.mark.skipif(PLATFORM != "osx", reason="macOS only")
 def test_info_plist(delete_files):
-    json_path, paths, *_ = check_output_from_shortcut(
+    json_path, paths, tmp_base_path, _ = check_output_from_shortcut(
         delete_files, "entitlements.json", remove_after=False, expected_output="entitlements"
     )
     metadata = json.loads(json_path.read_text())
@@ -354,7 +373,7 @@ def test_info_plist(delete_files):
     assert missing_items == []
     assert incorrect_items == {}
 
-    remove(json_path)
+    remove(json_path, target_prefix=tmp_base_path, base_prefix=tmp_base_path)
 
 
 @pytest.mark.skipif(PLATFORM != "osx", reason="macOS only")
@@ -381,14 +400,14 @@ def test_info_plist_duplicate():
 
 @pytest.mark.skipif(PLATFORM != "osx", reason="macOS only")
 def test_osx_symlinks(delete_files):
-    json_path, paths, _, output = check_output_from_shortcut(
+    json_path, paths, tmp_base_path, output = check_output_from_shortcut(
         delete_files, "osx_symlinks.json", remove_after=False
     )
     app_dir = next(p for p in paths if p.name.endswith(".app"))
     symlinked_python = app_dir / "Contents" / "Resources" / "python"
     assert output.strip() == str(symlinked_python)
     assert symlinked_python.resolve() == (Path(DEFAULT_PREFIX) / "bin" / "python").resolve()
-    remove(json_path)
+    remove(json_path, target_prefix=tmp_base_path, base_prefix=tmp_base_path)
 
 
 def _dump_ls_services():
@@ -423,7 +442,9 @@ def test_file_type_association_no_event_handler(delete_files, request):
         file_to_open=test_file,
         remove_after=False,
     )
-    request.addfinalizer(lambda: remove(abs_json_path, base_prefix=tmp_base_path))
+    request.addfinalizer(
+        lambda: remove(abs_json_path, target_prefix=tmp_base_path, base_prefix=tmp_base_path)
+    )
     app_dir = next(p for p in paths if p.name.endswith(".app"))
     info = app_dir / "Contents" / "Info.plist"
     plist = plistlib.loads(info.read_bytes())

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -159,9 +159,7 @@ class TestShortcutRecording:
         assert len(data["shortcuts"]) == 1
 
     @pytest.mark.skipif(sys.platform == "win32", reason="chmod doesn't work on Windows")
-    def test_record_shortcuts_handles_permission_error(
-        self, tmp_path: Path, caplog
-    ) -> None:
+    def test_record_shortcuts_handles_permission_error(self, tmp_path: Path, caplog) -> None:
         """record_shortcuts() should not raise when prefix is read-only."""
         # Create a read-only directory
         readonly_prefix = tmp_path / "readonly"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
 import sys
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 import pytest
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 from menuinst.api import (
     _install_adapter,
@@ -22,9 +21,29 @@ from menuinst.api import (
 from menuinst.platforms import Menu
 from menuinst.utils import MENUINST_TOML_SCHEMA_VERSION, parse_schemaver, read_menuinst_toml
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 # Placeholder distribution names for tests
 DIST_NAME = "Something"
 DIST_NAME_ALT = "SomethingElse"
+
+
+@contextmanager
+def make_readonly(path: "Path"):
+    """Make a path read-only, restoring permissions on exit."""
+    if sys.platform == "win32":
+        subprocess.run(["icacls", str(path), "/deny", f"{os.getlogin()}:(W)"], check=True)
+        try:
+            yield
+        finally:
+            subprocess.run(["icacls", str(path), "/remove:d", os.getlogin()], check=True)
+    else:
+        os.chmod(path, 0o555)
+        try:
+            yield
+        finally:
+            os.chmod(path, 0o755)
 
 
 class TestGetDistributionName:
@@ -158,62 +177,46 @@ class TestShortcutRecording:
         assert "distribution_name" not in data
         assert len(data["shortcuts"]) == 1
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="chmod doesn't work on Windows")
     def test_record_shortcuts_handles_permission_error(self, tmp_path: Path, caplog) -> None:
         """record_shortcuts() should not raise when prefix is read-only."""
-        # Create a read-only directory
-        readonly_prefix = tmp_path / "readonly"
-        readonly_prefix.mkdir()
-        os.chmod(readonly_prefix, 0o555)
+        prefix = tmp_path / "readonly"
+        prefix.mkdir()
+        menu_dir = prefix / "Menu"
+        menu_dir.mkdir()
 
-        try:
-            with caplog.at_level(logging.DEBUG):
-                # This should NOT raise PermissionError
-                record_shortcuts(
-                    prefix=readonly_prefix,
-                    base_prefix=readonly_prefix,
-                    source="test.json",
-                    paths=[tmp_path / "fake" / "path" / "shortcut.desktop"],
-                )
+        # Pre-create empty TOML so the test is consistent with test_remove_* below
+        write_menuinst_toml(prefix, {})
 
-            # Should log a debug message about permission denied
-            assert "permission denied" in caplog.text.lower()
-        finally:
-            # Restore permissions for cleanup
-            os.chmod(readonly_prefix, 0o755)
+        with make_readonly(menu_dir), make_readonly(prefix), caplog.at_level(logging.DEBUG):
+            # This should NOT raise PermissionError
+            record_shortcuts(
+                prefix=prefix,
+                base_prefix=prefix,
+                source="test.json",
+                paths=[tmp_path / "fake" / "path" / "shortcut.desktop"],
+            )
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="chmod doesn't work on Windows")
+        assert "permission denied" in caplog.text.lower()
+
     def test_remove_shortcut_records_handles_permission_error(
         self, tmp_path: Path, caplog
     ) -> None:
         """remove_shortcut_records() should not raise when prefix is read-only."""
-        # Create a prefix with a menuinst.toml
         prefix = tmp_path / "prefix"
         prefix.mkdir()
         menu_dir = prefix / "Menu"
         menu_dir.mkdir()
 
-        # Write initial TOML data
         write_menuinst_toml(
             prefix,
             {"shortcuts": [{"source": "test.json", "path": "/fake/path"}]},
         )
 
-        # Make the directory read-only
-        os.chmod(menu_dir, 0o555)
-        os.chmod(prefix, 0o555)
+        with make_readonly(menu_dir), make_readonly(prefix), caplog.at_level(logging.DEBUG):
+            # This should NOT raise PermissionError
+            remove_shortcut_records(prefix, "test.json")
 
-        try:
-            with caplog.at_level(logging.DEBUG):
-                # This should NOT raise PermissionError
-                remove_shortcut_records(prefix, "test.json")
-
-            # Should log a debug message about permission denied
-            assert "permission denied" in caplog.text.lower()
-        finally:
-            # Restore permissions for cleanup
-            os.chmod(prefix, 0o755)
-            os.chmod(menu_dir, 0o755)
+        assert "permission denied" in caplog.text.lower()
 
 
 class TestInstallAdapter:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -154,6 +157,65 @@ class TestShortcutRecording:
         data = read_menuinst_toml(env_prefix)
         assert "distribution_name" not in data
         assert len(data["shortcuts"]) == 1
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod doesn't work on Windows")
+    def test_record_shortcuts_handles_permission_error(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """record_shortcuts() should not raise when prefix is read-only."""
+        # Create a read-only directory
+        readonly_prefix = tmp_path / "readonly"
+        readonly_prefix.mkdir()
+        os.chmod(readonly_prefix, 0o555)
+
+        try:
+            with caplog.at_level(logging.DEBUG):
+                # This should NOT raise PermissionError
+                record_shortcuts(
+                    prefix=readonly_prefix,
+                    base_prefix=readonly_prefix,
+                    source="test.json",
+                    paths=[tmp_path / "fake" / "path" / "shortcut.desktop"],
+                )
+
+            # Should log a debug message about permission denied
+            assert "permission denied" in caplog.text.lower()
+        finally:
+            # Restore permissions for cleanup
+            os.chmod(readonly_prefix, 0o755)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod doesn't work on Windows")
+    def test_remove_shortcut_records_handles_permission_error(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """remove_shortcut_records() should not raise when prefix is read-only."""
+        # Create a prefix with a menuinst.toml
+        prefix = tmp_path / "prefix"
+        prefix.mkdir()
+        menu_dir = prefix / "Menu"
+        menu_dir.mkdir()
+
+        # Write initial TOML data
+        write_menuinst_toml(
+            prefix,
+            {"shortcuts": [{"source": "test.json", "path": "/fake/path"}]},
+        )
+
+        # Make the directory read-only
+        os.chmod(menu_dir, 0o555)
+        os.chmod(prefix, 0o555)
+
+        try:
+            with caplog.at_level(logging.DEBUG):
+                # This should NOT raise PermissionError
+                remove_shortcut_records(prefix, "test.json")
+
+            # Should log a debug message about permission denied
+            assert "permission denied" in caplog.text.lower()
+        finally:
+            # Restore permissions for cleanup
+            os.chmod(prefix, 0o755)
+            os.chmod(menu_dir, 0o755)
 
 
 class TestInstallAdapter:


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR is created based on the feedback in https://github.com/conda/menuinst/issues/496.

When creating the feature for `menuinst.toml` we didn't account for `target_prefix` being read only, however, I believe that the origin of the new feature (https://github.com/conda/menuinst/pull/477) isn't the root cause of the issue but in fact that this revealed a previously hidden issue in the tests - in particular we shouldn't try to create files in `/usr` during the testing.

Tests now use a `temp` directory with a symlink/copy of` Python` instead of relying on `sys.prefix`, in particular since before these changes we relied on `/usr` and extrapolated this to `/usr/bin/python`.

#### Changes:

1. `check_output_from_shortcut` refactor — Use `temp` directory as `target_prefix` instead of `sys.prefix`. Create a symlink (Unix) or copy (Windows) of the Python executable so `{{ PYTHON }}` placeholder resolves correctly.
2. macOS test fixes — Several tests had latent bugs where `remove()` was called without prefixes. Now properly capture and pass `target_prefix`/`base_prefix`.
3. `PermissionError` handling — `record_shortcuts()` and `remove_shortcut_records()` now gracefully handle permission errors with a debug log instead of crashing. This also seems to be similar with how `.nonadmin` is handled. This allows `menuinst` to work in read-only environments (shortcut tracking is skipped, but installation succeeds).

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/menuinst/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/menuinst/blob/main/CONTRIBUTING.md -->
