### PR TITLE
Update test to account for pytest 9.1.*

### DIFF
--- a/tests/test_windows_menu_item.py
+++ b/tests/test_windows_menu_item.py
@@ -15,8 +15,10 @@ if TYPE_CHECKING:
     from menuinst.platforms.win import WindowsMenu, WindowsMenuItem
     from menuinst.utils import WinLex
 else:
-    WindowsMenu = pytest.importorskip("menuinst.platforms.win").WindowsMenu
-    WindowsMenuItem = pytest.importorskip("menuinst.platforms.win").WindowsMenuItem
+    WindowsMenu = pytest.importorskip("menuinst.platforms.win", exc_type=ImportError).WindowsMenu
+    WindowsMenuItem = pytest.importorskip(
+        "menuinst.platforms.win", exc_type=ImportError
+    ).WindowsMenuItem
     WinLex = pytest.importorskip("menuinst.utils").WinLex
 
 # DEFAULT_PATH is actually not used to write any actual file,


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This PR contains a test update due to a deprecation that was removed in `pytest` 9.1: https://docs.pytest.org/en/stable/deprecations.html#pytest-importorskip-default-behavior-regarding-importerror
I noticed this error first in https://github.com/conda/menuinst/pull/505 where the error showed up on Linux (where `pytest 9.1.1` was used):
```
tests/test_windows_menu_item.py:18: in <module>
    WindowsMenu = pytest.importorskip("menuinst.platforms.win").WindowsMenu
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../../miniconda3/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:999: in exec_module
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
../../../miniconda3/lib/python3.12/site-packages/menuinst/platforms/win.py:17: in <module>
    from .win_utils.knownfolders import folder_path as windows_folder_path
../../../miniconda3/lib/python3.12/site-packages/menuinst/platforms/win_utils/knownfolders.py:32: in <module>
    from ctypes import windll, wintypes
E   ImportError: cannot import name 'windll' from 'ctypes' (/home/runner/miniconda3/lib/python3.12/ctypes/__init__.py)
```
If I compare to the latest run on main, `pytest 9.0.3` was used which would explain why this failed in the linked PR.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/menuinst/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/menuinst/blob/main/CONTRIBUTING.md -->
