### PR TITLE
Fix content writer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,7 @@ jobs:
           requirements="--file tests/requirements.txt"
           if [[ -f "tests/requirements-${{ runner.os }}" ]]; then
             requirements+=" tests/requirements-${{ runner.os }}"
+          fi
           conda install -yq --solver libmamba \
             $requirements \
             python=${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,10 +70,13 @@ jobs:
       - name: Add dependencies
         shell: bash -el {0}
         run: |
-          # Clear history in base env so there are no pins
+          # Clear history in base env so there are no pins
           echo > "$CONDA_PREFIX/conda-meta/history"
+          requirements="--file tests/requirements.txt"
+          if [[ -f "tests/requirements-${{ runner.os }}" ]]; then
+            requirements+=" tests/requirements-${{ runner.os }}"
           conda install -yq --solver libmamba \
-            --file tests/requirements.txt \
+            $requirements \
             python=${{ matrix.python-version }}
 
       - shell: bash -el {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
           echo > "$CONDA_PREFIX/conda-meta/history"
           requirements="--file tests/requirements.txt"
           if [[ -f "tests/requirements-${{ runner.os }}" ]]; then
-            requirements+=" tests/requirements-${{ runner.os }}"
+            requirements+=" --file tests/requirements-${{ runner.os }}"
           fi
           conda install -yq --solver libmamba \
             $requirements \

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import configparser
 import os
 import shlex
 import shutil
@@ -110,16 +109,15 @@ class LinuxMenu(Menu):
     #
 
     def _write_directory_entry(self) -> Path:
-        config = configparser.ConfigParser()
-        config.optionxform = str  # preserve key case
-        config["Desktop Entry"] = {
-            "Type": "Directory",
-            "Encoding": "UTF-8",
-            "Name": _escape_desktop_string(self.render(self.name)),
-        }
+        lines = [
+            "[Desktop Entry]",
+            "Type=Directory",
+            "Encoding=UTF-8",
+            f"Name={self.render(self.name)}",
+        ]
         log.debug("Writing directory entry at %s", self.directory_entry_location)
         with open(self.directory_entry_location, "w") as f:
-            config.write(f, space_around_delimiters=False)
+            f.write("\n".join(lines))
 
         return self.directory_entry_location
 
@@ -255,30 +253,27 @@ class LinuxMenuItem(MenuItem):
         if self.location.exists():
             log.warning("%s: Overwriting existing file at %s.", self._log_name, self.location)
 
-        config = configparser.ConfigParser()
-        config.optionxform = str  # preserve key case
-        config["Desktop Entry"] = {
-            "Type": "Application",
-            "Encoding": "UTF-8",
-            "Name": _escape_desktop_string(self.render_key("name")),
-            "Exec": _escape_desktop_string(self._command()),
-            "Terminal": str(self.render_key("terminal")).lower(),
-        }
+        lines = [
+            "[Desktop Entry]",
+            "Type=Application",
+            "Encoding=UTF-8",
+            f"Name={_escape_desktop_string(self.render_key('name'))}",
+            f"Exec={_escape_desktop_string(self._command())}",
+            f"Terminal={str(self.render_key('terminal')).lower()}",
+        ]
 
         icon = self.render_key("icon")
         if icon:
-            config["Desktop Entry"]["Icon"] = _escape_desktop_string(self.render_key("icon"))
+            lines.append("Icon={_escape_desktop_string(self.render_key('icon')}")
 
         description = self.render_key("description")
         if description:
-            config["Desktop Entry"]["Comment"] = _escape_desktop_string(
-                self.render_key("description")
-            )
+            lines.append(f"Comment={_escape_desktop_string(self.render_key('description'))}")
 
         working_dir = self.render_key("working_dir")
         if working_dir:
             Path(os.path.expandvars(working_dir)).mkdir(parents=True, exist_ok=True)
-            config["Desktop Entry"]["Path"] = _escape_desktop_string(str(working_dir))
+            lines.append(f"Path={_escape_desktop_string(str(working_dir))}")
 
         for key in menuitem_defaults["platforms"]["linux"]:
             if key in (*menuitem_defaults, "glob_patterns"):
@@ -290,12 +285,12 @@ class LinuxMenuItem(MenuItem):
                 value = str(value).lower()
             elif isinstance(value, (list, tuple)):
                 value = ";".join(value) + ";"
-            config["Desktop Entry"][key] = (
-                _escape_desktop_string(value) if isinstance(value, str) else value
-            )
+            value = _escape_desktop_string(value) if isinstance(value, str) else value
+            lines.append(f"{key}={value}")
 
         with open(self.location, "w") as f:
-            config.write(f, space_around_delimiters=False)
+            f.write("\n".join(lines))
+            f.write("\n")
 
     def _maybe_register_mime_types(self, register: bool = True):
         mime_types = self.render_key("MimeType")

--- a/news/ghsa-fqh4-w37r-x339-escape-desktop-entries
+++ b/news/ghsa-fqh4-w37r-x339-escape-desktop-entries
@@ -7,7 +7,7 @@
 * Escape white characters in Linux desktop files.
   The [freedesktop.org](https://specifications.freedesktop.org/desktop-entry/latest/value-types.html)
   specification allows for white space, which can be used to inject a malicious `Exec` instruction
-  into unrelated fields such as `Description`. (ghsa-fqh4-w37r-x339)
+  into unrelated fields such as `Description`. (ghsa-fqh4-w37r-x339, #514)
 
 ### Deprecations
 

--- a/tests/data/jsons/pwnd.json
+++ b/tests/data/jsons/pwnd.json
@@ -1,12 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
   "$id": "https://raw.githubusercontent.com/conda/menuinst/refs/heads/main/menuinst/data/menuinst.schema.json",
-  "menu_name":"PWNMenu",
-  "menu_items":[
+  "menu_name": "PWNMenu",
+  "menu_items": [
     {
-      "name":"PWNItem",
+      "name": "PWNItem",
       "activate": false,
-      "command": ["/bin/sh", "-c", "echo legit"],
+      "command": [
+        "/bin/sh",
+        "-c",
+        "echo legit"
+      ],
       "description": "Legit description\nExec=/bin/sh -c 'echo pwnd'",
       "platforms": {
         "linux": {}

--- a/tests/requirements-Linux.txt
+++ b/tests/requirements-Linux.txt
@@ -1,0 +1,1 @@
+pyobject

--- a/tests/requirements-Linux.txt
+++ b/tests/requirements-Linux.txt
@@ -1,1 +1,1 @@
-pyobject
+pygobject

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,7 +4,6 @@ conda
 # see https://github.com/conda/conda/issues/15287
 conda-libmamba-solver>=25.4.0
 pydantic>=2
-pyobject; sys_platform == 'linux'
 pytest
 pytest-cov
 pytest-mock


### PR DESCRIPTION
### Description

The quotation of the configparser module breaks commands, so return to manual file writing. This is still safe since control characters are escaped.

Also fix malformed requirements.txt file for conda deps.

### Checklist - did you ...

- [X] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
- [X] Add / update necessary tests?
- [X] Add / update outdated documentation?


