### PR TITLE
Replace .dict with .model_dump due to DeprecationWarning

### DIFF
--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -123,7 +123,7 @@ def test_package_1_linux(tmpdir, conda_cli):
 def test_package_1_osx(tmpdir, conda_cli):
     with install_package_1(tmpdir, conda_cli) as (prefix, menu_file):
         meta = validate(menu_file)
-        menu_items = [item.dict() for item in meta.menu_items]
+        menu_items = [item.model_dump() for item in meta.menu_items]
         menu = Menu(meta.menu_name, str(prefix), BASE_PREFIX)
         items = [menu]
         # First case, activation is on, output should be the prefix path


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

From https://github.com/conda/menuinst/actions/runs/30272409486/job/89997958067?pr=526 I noticed:
```
  /Users/runner/work/menuinst/menuinst/tests/test_conda.py:126: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    menu_items = [item.dict() for item in meta.menu_items]
```
This PR resolves that deprecation warning.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/menuinst/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/menuinst/blob/main/CONTRIBUTING.md -->
