### PR TITLE
Pass the opened file or URL to Linux shortcuts via an Exec field code

### DIFF
--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -19,6 +19,9 @@ from .base import Menu, MenuItem, menuitem_defaults
 
 log = getLogger(__name__)
 
+# https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html
+FIELD_CODES = ("%f", "%F", "%u", "%U")
+
 
 def _escape_desktop_string(value: str) -> str:
     """
@@ -234,7 +237,24 @@ class LinuxMenuItem(MenuItem):
                 check=False,
             )
 
-    def _command(self) -> str:
+    def _field_code(self) -> str:
+        """
+        Field code to append to ``Exec`` so file managers can pass the opened
+        file or URL to the shortcut, or an empty string if none is needed.
+        """
+        command = self.render_key("command") or ()
+        if any(code in arg for arg in command for code in FIELD_CODES):
+            # The item supplies its own field code; adding a second one would
+            # make the launcher pass the argument twice.
+            return ""
+        mime_types = self.render_key("MimeType") or ()
+        if not mime_types:
+            return ""
+        if all(mime_type.startswith("x-scheme-handler/") for mime_type in mime_types):
+            return "%u"
+        return "%f"
+
+    def _command(self, field_code: str = "") -> str:
         parts = []
         precommand = self.render_key("precommand")
         if precommand:
@@ -246,8 +266,15 @@ class LinuxMenuItem(MenuItem):
             else:
                 activate = "shell.bash activate"
             parts.append(f'eval "$("{conda_exe}" {activate} "{self.menu.prefix}")"')
-        parts.append(" ".join(UnixLex.quote_args(self.render_key("command"))))
-        return "bash -c " + shlex.quote(" && ".join(parts))
+        command = " ".join(UnixLex.quote_args(self.render_key("command")))
+        if not field_code:
+            parts.append(command)
+            return "bash -c " + shlex.quote(" && ".join(parts))
+        # `bash -c SCRIPT NAME ARGS...` assigns NAME to $0, so the field code
+        # must be preceded by a placeholder or the launcher's argument would be
+        # swallowed by $0 instead of reaching "$@".
+        parts.append(f'{command} "$@"')
+        return "bash -c " + shlex.quote(" && ".join(parts)) + f" bash {field_code}"
 
     def _write_desktop_file(self):
         if self.location.exists():
@@ -258,7 +285,7 @@ class LinuxMenuItem(MenuItem):
             "Type=Application",
             "Encoding=UTF-8",
             f"Name={_escape_desktop_string(self.render_key('name'))}",
-            f"Exec={_escape_desktop_string(self._command())}",
+            f"Exec={_escape_desktop_string(self._command(self._field_code()))}",
             f"Terminal={str(self.render_key('terminal')).lower()}",
         ]
 

--- a/menuinst/platforms/linux.py
+++ b/menuinst/platforms/linux.py
@@ -274,7 +274,7 @@ class LinuxMenuItem(MenuItem):
         # must be preceded by a placeholder or the launcher's argument would be
         # swallowed by $0 instead of reaching "$@".
         parts.append(f'{command} "$@"')
-        return "bash -c " + shlex.quote(" && ".join(parts)) + f" bash {field_code}"
+        return "bash -c " + shlex.quote(" && ".join(parts)) + f" name_placeholder {field_code}"
 
     def _write_desktop_file(self):
         if self.location.exists():

--- a/news/536-linux-exec-field-code
+++ b/news/536-linux-exec-field-code
@@ -1,0 +1,22 @@
+### Enhancements
+
+* Add a `%f` (or `%u` for URL scheme handlers) field code to the `Exec` line of
+  Linux `.desktop` files when the menu item declares a `MimeType`, so file
+  managers can pass the opened file or URL to the shortcut. Items that already
+  carry a field code in their own `command` are left untouched. (#536)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/tests/test_linux_menu_item.py
+++ b/tests/test_linux_menu_item.py
@@ -1,0 +1,91 @@
+"""Unit tests for the ``.desktop`` file written by ``LinuxMenuItem``."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+
+import pytest
+
+from menuinst.platforms.linux import LinuxMenu, LinuxMenuItem
+
+
+@pytest.fixture()
+def desktop_entry(tmp_path, monkeypatch):
+    """Return a factory that writes a desktop entry and hands back its contents."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+    def factory(**metadata) -> dict[str, str]:
+        menu = LinuxMenu("Test Menu", prefix=sys.prefix, base_prefix=sys.prefix)
+        menu._ensure_directories_exist()
+        metadata = {"name": "Test Item", "activate": False, **metadata}
+        item = LinuxMenuItem(menu, metadata)
+        # `MenuItem.__init__` flattens for the platform the tests run on; force
+        # Linux so `platforms.linux` keys are picked up off Linux too.
+        item.metadata = item._flatten_for_platform(item._data, platform="linux")
+        item._write_desktop_file()
+        return dict(
+            line.split("=", 1) for line in item.location.read_text().splitlines() if "=" in line
+        )
+
+    return factory
+
+
+def test_no_mime_type_has_no_field_code(desktop_entry):
+    entry = desktop_entry(command=["echo", "hi"])
+    assert not entry["Exec"].endswith(("%f", "%F", "%u", "%U"))
+
+
+def test_mime_type_adds_file_field_code(desktop_entry):
+    entry = desktop_entry(
+        command=["echo", "hi"],
+        platforms={"linux": {"MimeType": ["application/x-menuinst"]}},
+    )
+    assert entry["Exec"].endswith('"$@"\' bash %f')
+
+
+def test_url_scheme_handler_adds_url_field_code(desktop_entry):
+    entry = desktop_entry(
+        command=["echo", "hi"],
+        platforms={"linux": {"MimeType": ["x-scheme-handler/menuinst"]}},
+    )
+    assert entry["Exec"].endswith('"$@"\' bash %u')
+
+
+def test_mixed_mime_types_add_file_field_code(desktop_entry):
+    entry = desktop_entry(
+        command=["echo", "hi"],
+        platforms={"linux": {"MimeType": ["x-scheme-handler/menuinst", "application/x-menuinst"]}},
+    )
+    assert entry["Exec"].endswith('"$@"\' bash %f')
+
+
+def test_existing_field_code_is_not_duplicated(desktop_entry):
+    entry = desktop_entry(
+        command=["echo", "%f"],
+        platforms={"linux": {"MimeType": ["application/x-menuinst"]}},
+    )
+    assert entry["Exec"].count("%f") == 1
+    assert '"$@"' not in entry["Exec"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Requires a POSIX shell")
+def test_field_code_argument_reaches_the_command(desktop_entry, tmp_path):
+    """The launcher's argument must survive `bash -c` and land in the command."""
+    written = tmp_path / "written.txt"
+    entry = desktop_entry(
+        command=[
+            sys.executable,
+            "-c",
+            f"import pathlib, sys; pathlib.Path({str(written)!r}).write_text(sys.argv[1])",
+        ],
+        platforms={"linux": {"MimeType": ["application/x-menuinst"]}},
+    )
+    opened = tmp_path / "opened.menuinst"
+    opened.touch()
+    # Stand in for the file manager, which substitutes the field code before
+    # splitting `Exec` into arguments.
+    subprocess.run(shlex.split(entry["Exec"].replace("%f", str(opened))), check=True)
+    assert written.read_text() == str(opened)

--- a/tests/test_linux_menu_item.py
+++ b/tests/test_linux_menu_item.py
@@ -7,8 +7,13 @@ import subprocess
 import sys
 
 import pytest
+from conftest import PLATFORM
 
 from menuinst.platforms.linux import LinuxMenu, LinuxMenuItem
+
+pytestmark = pytest.mark.skipif(
+    PLATFORM != "linux", reason="This file contains tests that are Linux only."
+)
 
 
 @pytest.fixture()
@@ -16,15 +21,15 @@ def desktop_entry(tmp_path, monkeypatch):
     """Return a factory that writes a desktop entry and hands back its contents."""
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    base_prefix = tmp_path / "base"
+    prefix = base_prefix / "envs" / "test"
+    prefix.mkdir(parents=True)
 
     def factory(**metadata) -> dict[str, str]:
-        menu = LinuxMenu("Test Menu", prefix=sys.prefix, base_prefix=sys.prefix)
+        menu = LinuxMenu("Test Menu", prefix=str(prefix), base_prefix=str(base_prefix))
         menu._ensure_directories_exist()
         metadata = {"name": "Test Item", "activate": False, **metadata}
         item = LinuxMenuItem(menu, metadata)
-        # `MenuItem.__init__` flattens for the platform the tests run on; force
-        # Linux so `platforms.linux` keys are picked up off Linux too.
-        item.metadata = item._flatten_for_platform(item._data, platform="linux")
         item._write_desktop_file()
         return dict(
             line.split("=", 1) for line in item.location.read_text().splitlines() if "=" in line
@@ -43,7 +48,7 @@ def test_mime_type_adds_file_field_code(desktop_entry):
         command=["echo", "hi"],
         platforms={"linux": {"MimeType": ["application/x-menuinst"]}},
     )
-    assert entry["Exec"].endswith('"$@"\' bash %f')
+    assert entry["Exec"].endswith('"$@"\' name_placeholder %f')
 
 
 def test_url_scheme_handler_adds_url_field_code(desktop_entry):
@@ -51,7 +56,7 @@ def test_url_scheme_handler_adds_url_field_code(desktop_entry):
         command=["echo", "hi"],
         platforms={"linux": {"MimeType": ["x-scheme-handler/menuinst"]}},
     )
-    assert entry["Exec"].endswith('"$@"\' bash %u')
+    assert entry["Exec"].endswith('"$@"\' name_placeholder %u')
 
 
 def test_mixed_mime_types_add_file_field_code(desktop_entry):
@@ -59,7 +64,7 @@ def test_mixed_mime_types_add_file_field_code(desktop_entry):
         command=["echo", "hi"],
         platforms={"linux": {"MimeType": ["x-scheme-handler/menuinst", "application/x-menuinst"]}},
     )
-    assert entry["Exec"].endswith('"$@"\' bash %f')
+    assert entry["Exec"].endswith('"$@"\' name_placeholder %f')
 
 
 def test_existing_field_code_is_not_duplicated(desktop_entry):
@@ -71,7 +76,6 @@ def test_existing_field_code_is_not_duplicated(desktop_entry):
     assert '"$@"' not in entry["Exec"]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Requires a POSIX shell")
 def test_field_code_argument_reaches_the_command(desktop_entry, tmp_path):
     """The launcher's argument must survive `bash -c` and land in the command."""
     written = tmp_path / "written.txt"


### PR DESCRIPTION
Allow mime types to be auto-infered by filetype association

<details><summary>Claude summary and details</summary>

> **Opened by an AI agent (Claude) acting on behalf of @hmaarrfk, who has reviewed and takes responsibility for this change.**

Draft, because the questions under "Open questions" below deserve a maintainer opinion before this is polished.

### Description

A Linux menu item that declares `MimeType` gets registered as a handler for that type (`_register_mime_types` writes it into `mimeapps.list`), but the generated `Exec` line carries no [field code](https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html). There is no `%f`, `%F`, `%u` or `%U` anywhere in `menuinst/platforms/linux.py`, at any version — 2.4.2 has none either, so this is long-standing rather than a regression.

The consequence is that the file manager has nowhere to put the file: it launches the app with no argument.

The type does get registered, so the item shows up in "Open with" and is even installed as the default handler — it just cannot receive what the user opened.

There is a workaround today, and the test fixtures use it: the item author threads a field code through their own `command`, as `tests/data/jsons/file_types.json` and `url_protocols.json` do. That works, but it puts a Linux-specific launcher detail into user metadata, and it is not what menuinst does on the other platforms.

#### This is what menuinst already does on Windows

`WindowsMenuItem._process_command(with_arg1=True)` injects `%1` into the command, and `_register_file_extensions` / `_register_url_protocols` both call it that way:

https://github.com/conda/menuinst/blob/main/menuinst/platforms/win.py#L376-L382

```python
# Ensure "%1" is present and quoted when requested
if with_arg1 and all("%1" not in arg for arg in command):
    command.append('"%1"')
```

So auto-adding a field code on Linux when the item declares a `MimeType` is the symmetric behaviour, not a new concept — including the "don't add it if the author already supplied one" guard, which this PR copies.

#### The `bash -c` subtlety

`LinuxMenuItem._command` wraps everything in `bash -c '<script>'`. A naively appended trailing `%f` does **not** work: `bash -c SCRIPT NAME ARGS...` assigns `NAME` to `$0`, so the launcher's argument is swallowed.

```console
$ bash -c 'echo "got:[$*]"' /tmp/file.nc
got:[]
$ bash -c 'echo "got:[$*]"' bash /tmp/file.nc
got:[/tmp/file.nc]
```

So the emitted form is `"$@"` inside the quoted script plus a literal `bash` to occupy `$0`:

```
Exec=bash -c '<script> "$@"' bash %f
```

#### What the patch does

* `_field_code()` returns `%u` if every declared MIME type is an `x-scheme-handler/…` scheme, `%f` if any is a real file type, and `""` if there is no `MimeType` or if the rendered `command` already contains a field code.
* `_command()` takes an optional `field_code`; when it is empty the output is byte-for-byte what it was before.

#### Open questions

I picked a default for each of these rather than block on them, and I am happy to change any of them:

1. **`%f` vs `%F`.** I chose singular `%f`/`%u`. They differ only for multi-file selection: `%F` hands several paths to one process, `%f` makes the launcher spawn one process per file. Singular is the conservative default for a wrapped `bash -c` script that may not expect more than one argument, and it mirrors the singular `%1` used on Windows. `%F`/`%U` would be a one-line change if you prefer it.
2. **`%u` for URL schemes.** `x-scheme-handler/…` MIME types are how Linux expresses what `CFBundleURLTypes` expresses on macOS and `url_protocols` on Windows, and the spec's `%u` is the URL form, so an item declaring only scheme handlers gets `%u`. An item declaring both gets `%f`; that mixed case is arguably better served by `%u` (which also accepts local paths) — I do not have a strong view.
3. **Inferring from `MimeType` vs an explicit schema key.** Inferring needs no schema change and no action from existing recipes. An explicit key (say `platforms.linux.field_code`) would be more predictable and would let an author opt out, at the cost of a schema bump. Inference plus the "author already supplied one" escape hatch seemed like the better trade, but this is your call.

### Testing

New `tests/test_linux_menu_item.py`, mirroring the existing `tests/test_windows_menu_item.py` in structure. It drives `_write_desktop_file` directly, so it runs on every platform rather than needing a Linux desktop session:

* no `MimeType` → no field code
* file MIME type → `%f`; `x-scheme-handler/…` only → `%u`; mixed → `%f`
* a field code already in `command` → not duplicated, and the `"$@"` wrapper is not applied
* an end-to-end check that stands in for the file manager: substitute the field code into `Exec`, `shlex.split` it, run it, and assert the command actually received the path. This is the test that fails if the `$0` detail above is got wrong.

```
$ pytest tests/test_linux_menu_item.py     # before the change
4 failed, 2 passed
$ pytest tests/test_linux_menu_item.py     # after
6 passed
```

(The 2 that pass before are the negative controls, as expected.)

**No existing shortcut changes.** I rendered the `Exec` line for every JSON fixture in `tests/data/jsons` that enables Linux, with and without the patch, and diffed:

```
file_types.json, url_protocols.json, sys-prefix.json, precommands.json, pwnd.json
→ identical
```

`file_types.json` and `url_protocols.json` are the only fixtures that declare `MimeType`, and both already carry their own field code, so the guard keeps them untouched. The Linux CI cases for file-type and URL-protocol association should therefore be unaffected.

Full suite on macOS (Python 3.12): `79 passed, 27 skipped, 1 failed`. The one failure is `tests/test_elevation.py::test_elevation`, which fails identically on unmodified `main` in this environment and is unrelated to this change.

`pre-commit run --all-files` passes (all 19 hooks).

**What I could not test.** I have no Linux desktop session here, so I could not run the `PLATFORM == "linux"` / `CI` tests — `test_file_type_association`, `test_url_protocol_association`, `test_desktop_files_escaping` — and I could not confirm against a real file manager that a double-click hands the path through as intended. The end-to-end test above emulates the launcher (substitute, split, execute) rather than being one. Linux CI on this PR is the real check.

</details>

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/menuinst/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation? Not yet — if you are happy with the inference rule I will document it alongside `MimeType`.
